### PR TITLE
Add Binary prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Velocity imperialVelocity = miles / time; // 4 mi/h
 
 Area metricArea = kilometres * miles; // 347.62 Km²
 Area imperialArea = miles * kilometres ; // 134.22 mi²
-Console.WriteLine($"Equal area: {metricArea.Equals(imperialArea)}"); // Equal area: true
+Console.WriteLine($"Equal area: {metricArea.Equals(imperialArea)}"); // Equal area: True
 
 Length metricSum = kilometres + miles - metres; // 37.308 Km
 Length imperialSum = miles + kilometres - metres; // 23.182 mi
-Console.WriteLine($"Equal length: {imperialSum.Equals(metricSum)}"); // Equal length: true
+Console.WriteLine($"Equal length: {imperialSum.Equals(metricSum)}"); // Equal length: True
 ```
 
 ### Type Safety
@@ -105,4 +105,12 @@ Mass mass = Mass.Metric<Tonne>(0.2);
 Mass foo = mass * time;
 Time bar = time * mass;
 var fooBar = mass * time;
+```
+
+### Binary Prefixes
+Different types of prefixes are also supported. This is useful for [IEC binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix).
+```csharp
+Data kibiByte = Data.Metric<Kibi, Byte>(1); // 1 KiB, binary prefix
+Data kiloByte = Data.Metric<Byte>(1024).ToMetric<Kilo, Byte>(); // 1 KB, metric prefix
+Console.WriteLine($"Equal amount of data: {kiloByte.Equals(kibiByte)}"); // Equal amount of data: True
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ var fooBar = mass * time;
 ### Binary Prefixes
 Different types of prefixes are also supported. This is useful for [IEC binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix).
 ```csharp
-Data kibiByte = Data.Metric<Kibi, Byte>(1); // 1 KiB, binary prefix
-Data kiloByte = Data.Metric<Byte>(1024).ToMetric<Kilo, Byte>(); // 1 KB, metric prefix
+Data kibiByte = Data.In<Kibi, Byte>(1); // 1 KiB, binary prefix
+Data kiloByte = Data.In<Byte>(1024).To<Kilo, Byte>(); // 1 KB, metric prefix
 Console.WriteLine($"Equal amount of data: {kiloByte.Equals(kibiByte)}"); // Equal amount of data: True
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A library to safely handle various types of quantities, typically physical quantities.
 
 [![master status](https://github.com/atmoos/Quantities/actions/workflows/dotnet.yml/badge.svg)](https://github.com/atmoos/Quantities/actions/workflows/dotnet.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/atmoos/Quantities/blob/master/LICENSE)
 
 ## Project Goals
 Dealing with quantities (Metre, Yard, etc.) is not trivial. There are many areas where things can go wrong, such as forgetting to convert from one unit to the next or converting the wrong way.
@@ -20,12 +20,17 @@ A concrete example helps to illustrate that point: A length may be represented i
 It's a library that is still evolving rapidly. Try at your own risk or - even better - contribute :-)
 
 ## ToDo
-- [ ] Enable [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix).
+- [x] Enable [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix).
   - Enabling things like "KiB", i.e. "kibi Byte".
 - [ ] Enable serialisation
 - [ ] Extend unit tests
 - [ ] More rigours benchmarking
 - [ ] Add more quantities
+- [ ] Add "Zero" and "One/Unit" static properties
+  - i.e. enabling additive and multiplicative identities.
+- [ ] Add a "Normalize()" method to each quantity
+  - This should then generate a "human readable" representation
+  - example: 3'456 Km/d => 40 m/s
 
 ## Examples
 Usage is designed to be intuitive using:

--- a/quantities.benchmark/CreateQuantities.cs
+++ b/quantities.benchmark/CreateQuantities.cs
@@ -1,0 +1,64 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Quantities.Prefixes;
+using Quantities.Quantities;
+using Quantities.Units.Si;
+using Quantities.Units.Si.Metric;
+
+namespace Quantities.Benchmark;
+
+public sealed class DummyObject
+{
+    private readonly Double value;
+    public DummyObject(in Double value) => this.value = value;
+    public static implicit operator Double(DummyObject obj) => obj.value;
+}
+public readonly struct DummyStruct
+{
+    private readonly Double value;
+    public DummyStruct(Double value) => this.value = value;
+    public static implicit operator Double(DummyStruct obj) => obj.value;
+}
+
+[MemoryDiagnoser]
+public class CreateQuantities
+{
+    private static readonly Random random = new();
+    private Double value = random.NextDouble();
+
+
+    [Benchmark(Baseline = true)]
+    public DummyObject CreateObject() => new DummyObject(this.value);
+
+    [Benchmark]
+    public DummyObject CreateObjectIn() => new DummyObject(in this.value);
+
+    [Benchmark]
+    public DummyStruct CreateStruct() => new DummyStruct(this.value);
+
+    [Benchmark]
+    public Length CreateLength() => Length.Si<Kilo, Metre>(in this.value);
+
+    [Benchmark]
+    public Velocity CreateVelocity() => Velocity.Si<Kilo, Metre>(in this.value).Per<Hour>();
+}
+
+/*
+// * Summary *
+
+BenchmarkDotNet=v0.12.1, OS=arch 
+Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=7.0.100
+  [Host]     : .NET Core 7.0.0 (CoreCLR 7.0.22.56001, CoreFX 7.0.22.56001), X64 RyuJIT
+  DefaultJob : .NET Core 7.0.0 (CoreCLR 7.0.22.56001, CoreFX 7.0.22.56001), X64 RyuJIT
+
+
+|         Method |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|--------------- |-----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|   CreateObject |  6.6147 ns | 0.0908 ns | 0.0805 ns | 1.000 |    0.00 | 0.0057 |     - |     - |      24 B |
+| CreateObjectIn |  6.0880 ns | 0.0495 ns | 0.0463 ns | 0.921 |    0.01 | 0.0057 |     - |     - |      24 B |
+|   CreateStruct |  0.0547 ns | 0.0147 ns | 0.0138 ns | 0.008 |    0.00 |      - |     - |     - |         - |
+|   CreateLength |  4.2311 ns | 0.0568 ns | 0.0504 ns | 0.640 |    0.01 |      - |     - |     - |         - |
+| CreateVelocity | 10.0543 ns | 0.0173 ns | 0.0135 ns | 1.522 |    0.02 | 0.0057 |     - |     - |      24 B |
+*/

--- a/quantities.benchmark/PrefixScalingBenchmarks.cs
+++ b/quantities.benchmark/PrefixScalingBenchmarks.cs
@@ -9,7 +9,7 @@ namespace Quantities.Benchmark;
 public class PrefixScalingBenchmarks
 {
     private static readonly Random rand = new();
-    private static readonly ToDouble toDouble = new();
+    private static readonly IPrefixInject<Double> toDouble = new ToDouble();
     private Double value;
 
     [Params(-20, -4, 0, 5, 23)]
@@ -52,28 +52,27 @@ public class PrefixScalingBenchmarks
 
 /*
 // * Summary *
-
-BenchmarkDotNet=v0.12.1, OS=arch 
+BenchmarkDotNet=v0.13.2, OS=arch 
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
-.NET Core SDK=7.0.100
-  [Host]     : .NET Core 7.0.0 (CoreCLR 7.0.22.56001, CoreFX 7.0.22.56001), X64 RyuJIT
-  DefaultJob : .NET Core 7.0.0 (CoreCLR 7.0.22.56001, CoreFX 7.0.22.56001), X64 RyuJIT
+.NET SDK=7.0.100
+  [Host]     : .NET 7.0.0 (7.0.22.56001), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.0 (7.0.22.56001), X64 RyuJIT AVX2
 
 
-|          Method | Exponent |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
-|---------------- |--------- |----------:|----------:|----------:|----------:|------:|--------:|
-|        Baseline |      -20 | 24.889 ns | 0.5345 ns | 0.9774 ns | 24.363 ns |  1.00 |    0.00 |
-| SiPrefixScaling |      -20 | 10.329 ns | 0.0296 ns | 0.0262 ns | 10.330 ns |  0.39 |    0.00 |
-|                 |          |           |           |           |           |       |         |
-|        Baseline |       -4 | 24.296 ns | 0.1143 ns | 0.1069 ns | 24.313 ns |  1.00 |    0.00 |
-| SiPrefixScaling |       -4 |  9.180 ns | 0.0385 ns | 0.0341 ns |  9.178 ns |  0.38 |    0.00 |
-|                 |          |           |           |           |           |       |         |
-|        Baseline |        0 | 14.965 ns | 0.0466 ns | 0.0389 ns | 14.959 ns |  1.00 |    0.00 |
-| SiPrefixScaling |        0 |  3.008 ns | 0.0073 ns | 0.0061 ns |  3.006 ns |  0.20 |    0.00 |
-|                 |          |           |           |           |           |       |         |
-|        Baseline |        5 | 24.376 ns | 0.2641 ns | 0.2471 ns | 24.264 ns |  1.00 |    0.00 |
-| SiPrefixScaling |        5 |  7.807 ns | 0.0225 ns | 0.0210 ns |  7.802 ns |  0.32 |    0.00 |
-|                 |          |           |           |           |           |       |         |
-|        Baseline |       23 | 24.242 ns | 0.5083 ns | 0.6428 ns | 23.734 ns |  1.00 |    0.00 |
-| SiPrefixScaling |       23 | 11.652 ns | 0.2653 ns | 0.2482 ns | 11.512 ns |  0.48 |    0.02 |
+|          Method | Exponent |      Mean |     Error |    StdDev | Ratio |
+|---------------- |--------- |----------:|----------:|----------:|------:|
+|        Baseline |      -20 | 24.759 ns | 0.1024 ns | 0.0799 ns |  1.00 |
+| SiPrefixScaling |      -20 |  9.348 ns | 0.0531 ns | 0.0471 ns |  0.38 |
+|                 |          |           |           |           |       |
+|        Baseline |       -4 | 24.927 ns | 0.1148 ns | 0.1074 ns |  1.00 |
+| SiPrefixScaling |       -4 |  7.765 ns | 0.1489 ns | 0.1392 ns |  0.31 |
+|                 |          |           |           |           |       |
+|        Baseline |        0 | 24.186 ns | 0.1129 ns | 0.1056 ns |  1.00 |
+| SiPrefixScaling |        0 |  3.368 ns | 0.0240 ns | 0.0225 ns |  0.14 |
+|                 |          |           |           |           |       |
+|        Baseline |        5 | 24.935 ns | 0.0541 ns | 0.0506 ns |  1.00 |
+| SiPrefixScaling |        5 |  7.988 ns | 0.0556 ns | 0.0520 ns |  0.32 |
+|                 |          |           |           |           |       |
+|        Baseline |       23 | 23.809 ns | 0.1636 ns | 0.1530 ns |  1.00 |
+| SiPrefixScaling |       23 | 10.629 ns | 0.0630 ns | 0.0589 ns |  0.45 |
 */

--- a/quantities.benchmark/PrefixScalingBenchmarks.cs
+++ b/quantities.benchmark/PrefixScalingBenchmarks.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Quantities.Prefixes;
 
@@ -12,7 +10,7 @@ public class PrefixScalingBenchmarks
     private static readonly IPrefixInject<Double> toDouble = new ToDouble();
     private Double value;
 
-    [Params(-20, -4, 0, 5, 23)]
+    [Params(-4, 0, 5)]
     public Int32 Exponent { get; set; }
 
     [GlobalSetup]
@@ -33,7 +31,10 @@ public class PrefixScalingBenchmarks
     }
 
     [Benchmark]
-    public Double SiPrefixScaling() => MetricPrefix.Scale(in this.value, toDouble);
+    public Double MetricPrefixScaling() => MetricPrefix.Scale(in this.value, toDouble);
+
+    [Benchmark]
+    public Double BinaryPrefixScaling() => BinaryPrefix.Scale(in this.value, toDouble);
 
     private sealed class ToDouble : IPrefixInject<Double>
     {
@@ -41,17 +42,11 @@ public class PrefixScalingBenchmarks
 
         public Double Inject<TPrefix>(in Double value) where TPrefix : IPrefix => value;
     }
-
-    public IEnumerable<(Int32 exp, Double scaling)> Map()
-    {
-        foreach (var exp in Enumerable.Range(-9, 19)) {
-            yield return (exp, Math.Pow(10, -exp));
-        }
-    }
 }
 
 /*
 // * Summary *
+
 BenchmarkDotNet=v0.13.2, OS=arch 
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
 .NET SDK=7.0.100
@@ -59,20 +54,17 @@ Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical 
   DefaultJob : .NET 7.0.0 (7.0.22.56001), X64 RyuJIT AVX2
 
 
-|          Method | Exponent |      Mean |     Error |    StdDev | Ratio |
-|---------------- |--------- |----------:|----------:|----------:|------:|
-|        Baseline |      -20 | 24.759 ns | 0.1024 ns | 0.0799 ns |  1.00 |
-| SiPrefixScaling |      -20 |  9.348 ns | 0.0531 ns | 0.0471 ns |  0.38 |
-|                 |          |           |           |           |       |
-|        Baseline |       -4 | 24.927 ns | 0.1148 ns | 0.1074 ns |  1.00 |
-| SiPrefixScaling |       -4 |  7.765 ns | 0.1489 ns | 0.1392 ns |  0.31 |
-|                 |          |           |           |           |       |
-|        Baseline |        0 | 24.186 ns | 0.1129 ns | 0.1056 ns |  1.00 |
-| SiPrefixScaling |        0 |  3.368 ns | 0.0240 ns | 0.0225 ns |  0.14 |
-|                 |          |           |           |           |       |
-|        Baseline |        5 | 24.935 ns | 0.0541 ns | 0.0506 ns |  1.00 |
-| SiPrefixScaling |        5 |  7.988 ns | 0.0556 ns | 0.0520 ns |  0.32 |
-|                 |          |           |           |           |       |
-|        Baseline |       23 | 23.809 ns | 0.1636 ns | 0.1530 ns |  1.00 |
-| SiPrefixScaling |       23 | 10.629 ns | 0.0630 ns | 0.0589 ns |  0.45 |
+|              Method | Exponent |      Mean |     Error |    StdDev | Ratio |
+|-------------------- |--------- |----------:|----------:|----------:|------:|
+|            Baseline |       -4 | 24.671 ns | 0.1431 ns | 0.1195 ns |  1.00 |
+| MetricPrefixScaling |       -4 |  7.808 ns | 0.0678 ns | 0.0601 ns |  0.32 |
+| BinaryPrefixScaling |       -4 |  3.031 ns | 0.0333 ns | 0.0312 ns |  0.12 |
+|                     |          |           |           |           |       |
+|            Baseline |        0 | 23.823 ns | 0.1862 ns | 0.1651 ns |  1.00 |
+| MetricPrefixScaling |        0 |  3.477 ns | 0.0996 ns | 0.1066 ns |  0.14 |
+| BinaryPrefixScaling |        0 |  3.014 ns | 0.0099 ns | 0.0083 ns |  0.13 |
+|                     |          |           |           |           |       |
+|            Baseline |        5 | 23.781 ns | 0.0595 ns | 0.0464 ns |  1.00 |
+| MetricPrefixScaling |        5 |  7.852 ns | 0.0594 ns | 0.0526 ns |  0.33 |
+| BinaryPrefixScaling |        5 |  7.003 ns | 0.0221 ns | 0.0185 ns |  0.29 |
 */

--- a/quantities.benchmark/PrefixScalingBenchmarks.cs
+++ b/quantities.benchmark/PrefixScalingBenchmarks.cs
@@ -6,7 +6,7 @@ using Quantities.Prefixes;
 
 namespace Quantities.Benchmark;
 
-public class SiPrefixScalingBenchmark
+public class PrefixScalingBenchmarks
 {
     private static readonly Random rand = new();
     private static readonly ToDouble toDouble = new();
@@ -33,7 +33,7 @@ public class SiPrefixScalingBenchmark
     }
 
     [Benchmark]
-    public Double SiPrefixScaling() => SiPrefix.Scale(in this.value, toDouble);
+    public Double SiPrefixScaling() => MetricPrefix.Scale(in this.value, toDouble);
 
     private sealed class ToDouble : IPrefixInject<Double>
     {

--- a/quantities.benchmark/quantities.benchmark.csproj
+++ b/quantities.benchmark/quantities.benchmark.csproj
@@ -13,8 +13,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2" Condition="'$(OS)' == 'Windows_NT'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\quantities\quantities.csproj" />

--- a/quantities.test/AreaTest.cs
+++ b/quantities.test/AreaTest.cs
@@ -1,6 +1,6 @@
 using Quantities.Units.Imperial.Area;
+using Quantities.Units.Other.Area;
 using Quantities.Units.Si.Metric;
-using Quantities.Unitss.Other.Area;
 
 namespace Quantities.Test;
 public class AreaTest

--- a/quantities.test/AreaTest.cs
+++ b/quantities.test/AreaTest.cs
@@ -13,7 +13,7 @@ public class AreaTest
         Area left = Area.Square<Metre>(20);
         Area right = Area.Square<Metre>(10);
         Area result = left + right;
-        Assert.Equal(30d, result, SiPrecision);
+        PrecisionIsBounded(30d, result);
     }
     [Fact]
     public void AddSquareHectoMetresToSquareKiloMetres()
@@ -21,14 +21,14 @@ public class AreaTest
         Area left = Area.Square<Kilo, Metre>(2);
         Area right = Area.Square<Hecto, Metre>(50);
         Area result = left + right;
-        Assert.Equal(2.5d, result, SiPrecision);
+        PrecisionIsBounded(2.5d, result);
     }
     [Fact]
     public void SquareMetresToSquareKilometers()
     {
         Area squareMetres = Area.Square<Metre>(1000);
-        Area squarekilometres = squareMetres.ToSquare<Kilo, Metre>();
-        Assert.Equal(1e-3d, squarekilometres, SiPrecision);
+        Area squareKilometres = squareMetres.ToSquare<Kilo, Metre>();
+        PrecisionIsBounded(1e-3d, squareKilometres);
     }
     [Fact]
     public void SquareMilesToSquareKilometers()
@@ -49,7 +49,7 @@ public class AreaTest
 
         Area actual = squareYards.ToSquareImperial<Foot>();
 
-        actual.Matches(expected, ImperialPrecision);
+        actual.Matches(expected, MediumPrecision - 1);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class AreaTest
 
         Length actual = area / length;
 
-        actual.Matches(expected);
+        actual.Matches(expected, MediumPrecision);
     }
     [Fact]
     public void PureArealDimensionDividedByLength()

--- a/quantities.test/Convenience.cs
+++ b/quantities.test/Convenience.cs
@@ -17,11 +17,19 @@ public static class Convenience
         PrecisionIsBounded(expected, actual, precision);
         Assert.Equal(expected.ToString(), actual.ToString());
     }
-    private static void PrecisionIsBounded(Double expected, Double actual, Int32 precision)
+    public static void PrecisionIsBounded(Double expected, Double actual, Int32 precision)
     {
-        const Int32 maxPrecision = 15;
+        const Int32 maxDoublePrecision = 16;
+        const Int32 maxRoundingPrecision = maxDoublePrecision - 1;
+        if (precision >= maxDoublePrecision) {
+            if (precision == maxDoublePrecision) {
+                Assert.Equal(expected, actual);
+                return;
+            }
+            throw new ArgumentOutOfRangeException(nameof(precision), precision, $"Doubles can't be compared to precisions higher than {maxDoublePrecision}.");
+        }
         Assert.Equal(expected, actual, precision);
-        if (precision < maxPrecision) {
+        if (precision < maxRoundingPrecision) {
             Assert.Throws<EqualException>(() => Assert.Equal(expected, actual, precision + 1));
         }
     }

--- a/quantities.test/Convenience.cs
+++ b/quantities.test/Convenience.cs
@@ -4,12 +4,15 @@ using Xunit.Sdk;
 namespace Quantities.Test;
 public static class Convenience
 {
-    public static Int32 SiPrecision => 15;
-    public static Int32 ImperialPrecision => 14;
+    private const Int32 fullPrecision = 16;
+    public static Int32 FullPrecision => fullPrecision;
+    public static Int32 MediumPrecision => fullPrecision - 1;
+    public static Int32 LowPrecision => fullPrecision - 2;
+    public static Int32 VeryLowPrecision => fullPrecision - 3;
     public static void Matches<TQuantity>(this TQuantity actual, TQuantity expected)
         where TQuantity : struct, IQuantity<TQuantity>, Dimensions.IDimension
     {
-        actual.Matches(expected, SiPrecision);
+        actual.Matches(expected, FullPrecision);
     }
     public static void Matches<TQuantity>(this TQuantity actual, TQuantity expected, Int32 precision)
         where TQuantity : struct, IQuantity<TQuantity>, Dimensions.IDimension
@@ -17,7 +20,7 @@ public static class Convenience
         PrecisionIsBounded(expected, actual, precision);
         Assert.Equal(expected.ToString(), actual.ToString());
     }
-    public static void PrecisionIsBounded(Double expected, Double actual, Int32 precision)
+    public static void PrecisionIsBounded(Double expected, Double actual, Int32 precision = fullPrecision)
     {
         const Int32 maxDoublePrecision = 16;
         const Int32 maxRoundingPrecision = maxDoublePrecision - 1;
@@ -29,7 +32,11 @@ public static class Convenience
             throw new ArgumentOutOfRangeException(nameof(precision), precision, $"Doubles can't be compared to precisions higher than {maxDoublePrecision}.");
         }
         Assert.Equal(expected, actual, precision);
-        if (precision < maxRoundingPrecision) {
+        if (precision <= maxRoundingPrecision) {
+            if (precision == maxRoundingPrecision) {
+                Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
+                return;
+            }
             Assert.Throws<EqualException>(() => Assert.Equal(expected, actual, precision + 1));
         }
     }

--- a/quantities.test/ConvenienceTest.cs
+++ b/quantities.test/ConvenienceTest.cs
@@ -1,0 +1,36 @@
+using Xunit.Sdk;
+
+namespace Quantities.Test;
+
+public class ConvenienceTest
+{
+    private const Double expectedValue = 1.2345678944444123;
+    private const Double actualOffBy16 = 1.2345678944444124;
+    private const Double actualOffBy15 = 1.2345678944444133;
+
+    [Fact]
+    public void PrecisionIsBoundedDoesntThrowOnEqualValues()
+    {
+        // This doesn't throw
+        PrecisionIsBounded(expectedValue, expectedValue, 16);
+    }
+
+    [Fact]
+    public void PrecisionIsBoundedOfOnSixteenthDecimal()
+    {
+        // This doesn't throw
+        PrecisionIsBounded(expectedValue, actualOffBy16, 15);
+
+        // This does!
+        Assert.Throws<EqualException>(() => PrecisionIsBounded(expectedValue, actualOffBy16, 16));
+    }
+    [Fact]
+    public void PrecisionIsBoundedOfOnFifteenthDecimal()
+    {
+        // This doesn't throw
+        PrecisionIsBounded(expectedValue, actualOffBy15, 14);
+
+        // This does!
+        Assert.Throws<EqualException>(() => PrecisionIsBounded(expectedValue, actualOffBy15, 15));
+    }
+}

--- a/quantities.test/DataRateTest.cs
+++ b/quantities.test/DataRateTest.cs
@@ -13,66 +13,66 @@ public class DataRateTest
     private const Double gibi = kibi * mebi;
 
     [Fact]
-    public void BitPerSecondToString() => FormattingMatches(v => DataRate.Metric<Bit>(v).PerSecond(), "bit/s");
+    public void BitPerSecondToString() => FormattingMatches(v => DataRate.In<Bit>(v).PerSecond(), "bit/s");
     [Fact]
-    public void BytePerSecondToString() => FormattingMatches(v => DataRate.Metric<Bytes>(v).PerSecond(), "B/s");
+    public void BytePerSecondToString() => FormattingMatches(v => DataRate.In<Bytes>(v).PerSecond(), "B/s");
     [Fact]
-    public void NibblePerSecondToString() => FormattingMatches(v => DataRate.Metric<Nibble>(v).PerSecond(), "N/s");
+    public void NibblePerSecondToString() => FormattingMatches(v => DataRate.In<Nibble>(v).PerSecond(), "N/s");
     [Fact]
-    public void KibiBitPerSecondToString() => FormattingMatches(v => DataRate.Metric<Kibi, Bit>(v).PerSecond(), "Kibit/s");
+    public void KibiBitPerSecondToString() => FormattingMatches(v => DataRate.In<Kibi, Bit>(v).PerSecond(), "Kibit/s");
     [Fact]
-    public void KiloBitPerSecondToString() => FormattingMatches(v => DataRate.Metric<Kilo, Bit>(v).PerSecond(), "Kbit/s");
+    public void KiloBitPerSecondToString() => FormattingMatches(v => DataRate.In<Kilo, Bit>(v).PerSecond(), "Kbit/s");
     [Fact]
-    public void KiloBytePerSecondToString() => FormattingMatches(v => DataRate.Metric<Kilo, Bytes>(v).PerSecond(), "KB/s");
+    public void KiloBytePerSecondToString() => FormattingMatches(v => DataRate.In<Kilo, Bytes>(v).PerSecond(), "KB/s");
     [Fact]
-    public void KibiBytePerSecondToString() => FormattingMatches(v => DataRate.Metric<Kibi, Bytes>(v).PerSecond(), "KiB/s");
+    public void KibiBytePerSecondToString() => FormattingMatches(v => DataRate.In<Kibi, Bytes>(v).PerSecond(), "KiB/s");
     [Fact]
     public void KibiBytePerSecondToKiloBytePerSecond()
     {
-        DataRate expected = DataRate.Metric<Kilo, Bytes>(12 * kibi / 1e3).PerSecond();
-        DataRate rate = DataRate.Metric<Kibi, Bytes>(12).PerSecond();
+        DataRate expected = DataRate.In<Kilo, Bytes>(12 * kibi / 1e3).PerSecond();
+        DataRate rate = DataRate.In<Kibi, Bytes>(12).PerSecond();
 
-        DataRate actual = rate.ToMetric<Kilo, Bytes>().PerSecond();
+        DataRate actual = rate.To<Kilo, Bytes>().PerSecond();
 
         actual.Matches(expected);
     }
     [Fact]
     public void KiloBytePerHourToBytePerSecond()
     {
-        DataRate expected = DataRate.Metric<Bytes>(10).PerSecond();
-        DataRate speed = DataRate.Metric<Kilo, Bytes>(36).Per<Hour>();
+        DataRate expected = DataRate.In<Bytes>(10).PerSecond();
+        DataRate speed = DataRate.In<Kilo, Bytes>(36).Per<Hour>();
 
-        DataRate actual = speed.ToMetric<Bytes>().PerSecond();
+        DataRate actual = speed.To<Bytes>().PerSecond();
 
         actual.Matches(expected);
     }
     [Fact]
     public void MebiBytePerHourToKiloBytePerSecond()
     {
-        DataRate expected = DataRate.Metric<Kilo, Bytes>(mebi / kilo).PerSecond();
-        DataRate speed = DataRate.Metric<Mebi, Bytes>(3600).Per<Hour>();
+        DataRate expected = DataRate.In<Kilo, Bytes>(mebi / kilo).PerSecond();
+        DataRate speed = DataRate.In<Mebi, Bytes>(3600).Per<Hour>();
 
-        DataRate actual = speed.ToMetric<Kilo, Bytes>().PerSecond();
+        DataRate actual = speed.To<Kilo, Bytes>().PerSecond();
 
         actual.Matches(expected);
     }
     [Fact]
     public void MebiBitPerHourToKiloBytePerSecond()
     {
-        DataRate expected = DataRate.Metric<Kilo, Bytes>(mebi / kilo).PerSecond();
-        DataRate speed = DataRate.Metric<Mebi, Bit>(3600 * 8).Per<Hour>();
+        DataRate expected = DataRate.In<Kilo, Bytes>(mebi / kilo).PerSecond();
+        DataRate speed = DataRate.In<Mebi, Bit>(3600 * 8).Per<Hour>();
 
-        DataRate actual = speed.ToMetric<Kilo, Bytes>().PerSecond();
+        DataRate actual = speed.To<Kilo, Bytes>().PerSecond();
 
         actual.Matches(expected);
     }
     [Fact]
     public void GibiBitPerHourToKiloBytePerMinute()
     {
-        DataRate expected = DataRate.Metric<Kilo, Bytes>(gibi / kilo).Per<Minute>();
-        DataRate speed = DataRate.Metric<Gibi, Bit>(60 * 8).Per<Hour>();
+        DataRate expected = DataRate.In<Kilo, Bytes>(gibi / kilo).Per<Minute>();
+        DataRate speed = DataRate.In<Gibi, Bit>(60 * 8).Per<Hour>();
 
-        DataRate actual = speed.ToMetric<Kilo, Bytes>().Per<Minute>();
+        DataRate actual = speed.To<Kilo, Bytes>().Per<Minute>();
 
         actual.Matches(expected);
     }
@@ -80,10 +80,10 @@ public class DataRateTest
     [Fact]
     public void KiloBytePerMinuteToMebiBitPerHour()
     {
-        DataRate expected = DataRate.Metric<Mebi, Bit>(60 * 8).Per<Hour>();
-        DataRate speed = DataRate.Metric<Kilo, Bytes>(mebi / kilo).Per<Minute>();
+        DataRate expected = DataRate.In<Mebi, Bit>(60 * 8).Per<Hour>();
+        DataRate speed = DataRate.In<Kilo, Bytes>(mebi / kilo).Per<Minute>();
 
-        DataRate actual = speed.ToMetric<Mebi, Bit>().Per<Hour>();
+        DataRate actual = speed.To<Mebi, Bit>().Per<Hour>();
 
         actual.Matches(expected);
     }
@@ -91,10 +91,10 @@ public class DataRateTest
     [Fact]
     public void KiloBytePerSecondToKiloBitPerSecond()
     {
-        DataRate expected = DataRate.Metric<Kilo, Bit>(16).PerSecond();
-        DataRate speed = DataRate.Metric<Kilo, Bytes>(2).PerSecond();
+        DataRate expected = DataRate.In<Kilo, Bit>(16).PerSecond();
+        DataRate speed = DataRate.In<Kilo, Bytes>(2).PerSecond();
 
-        DataRate actual = speed.ToMetric<Kilo, Bit>().PerSecond();
+        DataRate actual = speed.To<Kilo, Bit>().PerSecond();
 
         actual.Matches(expected);
     }
@@ -102,8 +102,8 @@ public class DataRateTest
     public void DataDividedByTimeIsDataRate()
     {
         Time time = Time.Si<Micro, Second>(12);
-        Data data = Data.Metric<Gibi, Nibble>(24);
-        DataRate expected = DataRate.Metric<Gibi, Nibble>(24 / 12).Per<Micro, Second>();
+        Data data = Data.In<Gibi, Nibble>(24);
+        DataRate expected = DataRate.In<Gibi, Nibble>(24 / 12).Per<Micro, Second>();
 
         DataRate actual = data / time;
 

--- a/quantities.test/DataRateTest.cs
+++ b/quantities.test/DataRateTest.cs
@@ -1,0 +1,101 @@
+using Quantities.Units.Si.Metric;
+
+using Bytes = Quantities.Units.Si.Metric.Byte;
+
+namespace Quantities.Test;
+
+public class DataRateTest
+{
+    private const Double kibi = 1024;
+    private const Double kilo = 1000;
+    private const Double mebi = kibi * kibi;
+    private const Double mega = kilo * kilo;
+    private const Double gibi = kibi * mebi;
+
+    [Fact]
+    public void BitPerSecondToString() => FormattingMatches(v => DataRate.Metric<Bit>(v).PerSecond(), "bit/s");
+    [Fact]
+    public void BytePerSecondToString() => FormattingMatches(v => DataRate.Metric<Bytes>(v).PerSecond(), "B/s");
+    [Fact]
+    public void NibblePerSecondToString() => FormattingMatches(v => DataRate.Metric<Nibble>(v).PerSecond(), "N/s");
+    [Fact]
+    public void KibiBitPerSecondToString() => FormattingMatches(v => DataRate.Metric<Kibi, Bit>(v).PerSecond(), "Kibit/s");
+    [Fact]
+    public void KiloBitPerSecondToString() => FormattingMatches(v => DataRate.Metric<Kilo, Bit>(v).PerSecond(), "Kbit/s");
+    [Fact]
+    public void KiloBytePerSecondToString() => FormattingMatches(v => DataRate.Metric<Kilo, Bytes>(v).PerSecond(), "KB/s");
+    [Fact]
+    public void KibiBytePerSecondToString() => FormattingMatches(v => DataRate.Metric<Kibi, Bytes>(v).PerSecond(), "KiB/s");
+    [Fact]
+    public void KibiBytePerSecondToKiloBytePerSecond()
+    {
+        DataRate expected = DataRate.Metric<Kilo, Bytes>(12 * kibi / 1e3).PerSecond();
+        DataRate rate = DataRate.Metric<Kibi, Bytes>(12).PerSecond();
+
+        DataRate actual = rate.ToMetric<Kilo, Bytes>().PerSecond();
+
+        actual.Matches(expected);
+    }
+    [Fact]
+    public void KiloBytePerHourToBytePerSecond()
+    {
+        DataRate expected = DataRate.Metric<Bytes>(10).PerSecond();
+        DataRate speed = DataRate.Metric<Kilo, Bytes>(36).Per<Hour>();
+
+        DataRate actual = speed.ToMetric<Bytes>().PerSecond();
+
+        actual.Matches(expected);
+    }
+    [Fact]
+    public void MebiBytePerHourToKiloBytePerSecond()
+    {
+        DataRate expected = DataRate.Metric<Kilo, Bytes>(mebi / kilo).PerSecond();
+        DataRate speed = DataRate.Metric<Mebi, Bytes>(3600).Per<Hour>();
+
+        DataRate actual = speed.ToMetric<Kilo, Bytes>().PerSecond();
+
+        actual.Matches(expected);
+    }
+    [Fact]
+    public void MebiBitPerHourToKiloBytePerSecond()
+    {
+        DataRate expected = DataRate.Metric<Kilo, Bytes>(mebi / kilo).PerSecond();
+        DataRate speed = DataRate.Metric<Mebi, Bit>(3600 * 8).Per<Hour>();
+
+        DataRate actual = speed.ToMetric<Kilo, Bytes>().PerSecond();
+
+        actual.Matches(expected);
+    }
+    [Fact]
+    public void GibiBitPerHourToKiloBytePerMinute()
+    {
+        DataRate expected = DataRate.Metric<Kilo, Bytes>(gibi / kilo).Per<Minute>();
+        DataRate speed = DataRate.Metric<Gibi, Bit>(60 * 8).Per<Hour>();
+
+        DataRate actual = speed.ToMetric<Kilo, Bytes>().Per<Minute>();
+
+        actual.Matches(expected);
+    }
+
+    [Fact]
+    public void KiloBytePerMinuteToMebiBitPerHour()
+    {
+        DataRate expected = DataRate.Metric<Mebi, Bit>(60 * 8).Per<Hour>();
+        DataRate speed = DataRate.Metric<Kilo, Bytes>(mebi / kilo).Per<Minute>();
+
+        DataRate actual = speed.ToMetric<Mebi, Bit>().Per<Hour>();
+
+        actual.Matches(expected);
+    }
+
+    [Fact]
+    public void KiloBytePerSecondToKiloBitPerSecond()
+    {
+        DataRate expected = DataRate.Metric<Kilo, Bit>(16).PerSecond();
+        DataRate speed = DataRate.Metric<Kilo, Bytes>(2).PerSecond();
+
+        DataRate actual = speed.ToMetric<Kilo, Bit>().PerSecond();
+
+        actual.Matches(expected);
+    }
+}

--- a/quantities.test/DataRateTest.cs
+++ b/quantities.test/DataRateTest.cs
@@ -98,4 +98,15 @@ public class DataRateTest
 
         actual.Matches(expected);
     }
+    [Fact]
+    public void DataDividedByTimeIsDataRate()
+    {
+        Time time = Time.Si<Micro, Second>(12);
+        Data data = Data.Metric<Gibi, Nibble>(24);
+        DataRate expected = DataRate.Metric<Gibi, Nibble>(24 / 12).Per<Micro, Second>();
+
+        DataRate actual = data / time;
+
+        actual.Matches(expected);
+    }
 }

--- a/quantities.test/DataTest.cs
+++ b/quantities.test/DataTest.cs
@@ -11,68 +11,68 @@ public class DataTest
     private const Double gibi = kibi * mebi;
 
     [Fact]
-    public void BitToString() => FormattingMatches(v => Data.Metric<Bit>(v), "bit");
+    public void BitToString() => FormattingMatches(v => Data.In<Bit>(v), "bit");
     [Fact]
-    public void ByteToString() => FormattingMatches(v => Data.Metric<Bytes>(v), "B");
+    public void ByteToString() => FormattingMatches(v => Data.In<Bytes>(v), "B");
     [Fact]
-    public void NibbleToString() => FormattingMatches(v => Data.Metric<Nibble>(v), "N");
+    public void NibbleToString() => FormattingMatches(v => Data.In<Nibble>(v), "N");
     [Fact]
-    public void KibiBitToString() => FormattingMatches(v => Data.Metric<Kibi, Bit>(v), "Kibit");
+    public void KibiBitToString() => FormattingMatches(v => Data.In<Kibi, Bit>(v), "Kibit");
     [Fact]
-    public void KiloBitToString() => FormattingMatches(v => Data.Metric<Kilo, Bit>(v), "Kbit");
+    public void KiloBitToString() => FormattingMatches(v => Data.In<Kilo, Bit>(v), "Kbit");
     [Fact]
-    public void KiloByteToString() => FormattingMatches(v => Data.Metric<Kilo, Bytes>(v), "KB");
+    public void KiloByteToString() => FormattingMatches(v => Data.In<Kilo, Bytes>(v), "KB");
     [Fact]
-    public void KibiByteToString() => FormattingMatches(v => Data.Metric<Kibi, Bytes>(v), "KiB");
+    public void KibiByteToString() => FormattingMatches(v => Data.In<Kibi, Bytes>(v), "KiB");
     [Fact]
     public void DefinitionOfNibble()
     {
-        Data definition = Data.Metric<Bit>(4);
-        Data oneNibble = Data.Metric<Nibble>(1);
+        Data definition = Data.In<Bit>(4);
+        Data oneNibble = Data.In<Nibble>(1);
 
         Assert.Equal(definition, oneNibble);
     }
     [Fact]
     public void DefinitionOfByte()
     {
-        Data definition = Data.Metric<Bit>(8);
-        Data oneByte = Data.Metric<Bytes>(1);
+        Data definition = Data.In<Bit>(8);
+        Data oneByte = Data.In<Bytes>(1);
 
         Assert.Equal(definition, oneByte);
     }
     [Fact]
     public void DefinitionOfKiloByte()
     {
-        Data definition = Data.Metric<Bit>(8 * 1000);
-        Data oneByte = Data.Metric<Kilo, Bytes>(1);
+        Data definition = Data.In<Bit>(8 * 1000);
+        Data oneByte = Data.In<Kilo, Bytes>(1);
 
         Assert.Equal(definition, oneByte);
     }
     [Fact]
     public void DefinitionOfKibiByte()
     {
-        Data definition = Data.Metric<Bit>(8 * kibi);
-        Data oneByte = Data.Metric<Kibi, Bytes>(1);
+        Data definition = Data.In<Bit>(8 * kibi);
+        Data oneByte = Data.In<Kibi, Bytes>(1);
 
         Assert.Equal(definition, oneByte);
     }
     [Fact]
     public void MebiByteToMegaByte()
     {
-        Data expected = Data.Metric<Mega, Bytes>(3 * mebi / 1e6);
-        Data mebiBytes = Data.Metric<Mebi, Bytes>(3);
+        Data expected = Data.In<Mega, Bytes>(3 * mebi / 1e6);
+        Data mebiBytes = Data.In<Mebi, Bytes>(3);
 
-        Data actual = mebiBytes.ToMetric<Mega, Bytes>();
+        Data actual = mebiBytes.To<Mega, Bytes>();
 
         actual.Matches(expected);
     }
     [Fact]
     public void GigaByteToGibiByte()
     {
-        Data expected = Data.Metric<Gibi, Bytes>(22 * 1e9 / gibi);
-        Data mebiBytes = Data.Metric<Giga, Bytes>(22);
+        Data expected = Data.In<Gibi, Bytes>(22 * 1e9 / gibi);
+        Data mebiBytes = Data.In<Giga, Bytes>(22);
 
-        Data actual = mebiBytes.ToMetric<Gibi, Bytes>();
+        Data actual = mebiBytes.To<Gibi, Bytes>();
 
         actual.Matches(expected);
     }
@@ -80,9 +80,9 @@ public class DataTest
     public void DataRateTimesTimeIsAmountOfData()
     {
         Time time = Time.Si<Milli, Second>(12);
-        DataRate rate = DataRate.Metric<Mega, Bit>(32).PerSecond();
+        DataRate rate = DataRate.In<Mega, Bit>(32).PerSecond();
         // Note that the units aren't preserved yet...
-        Data expected = Data.Metric<Kibi, Bytes>(12 * 32 / (8 * 1e3) * 1e6 / kibi);
+        Data expected = Data.In<Kibi, Bytes>(12 * 32 / (8 * 1e3) * 1e6 / kibi);
 
         Data actual = rate * time;
 

--- a/quantities.test/DataTest.cs
+++ b/quantities.test/DataTest.cs
@@ -76,4 +76,16 @@ public class DataTest
 
         actual.Matches(expected);
     }
+    [Fact]
+    public void DataRateTimesTimeIsAmountOfData()
+    {
+        Time time = Time.Si<Milli, Second>(12);
+        DataRate rate = DataRate.Metric<Mega, Bit>(32).PerSecond();
+        // Note that the units aren't preserved yet...
+        Data expected = Data.Metric<Kibi, Bytes>(12 * 32 / (8 * 1e3) * 1e6 / kibi);
+
+        Data actual = rate * time;
+
+        actual.Matches(expected);
+    }
 }

--- a/quantities.test/DataTest.cs
+++ b/quantities.test/DataTest.cs
@@ -1,0 +1,79 @@
+using Quantities.Units.Si.Metric;
+
+using Bytes = Quantities.Units.Si.Metric.Byte;
+
+namespace Quantities.Test;
+
+public class DataTest
+{
+    private const Double kibi = 1024;
+    private const Double mebi = kibi * kibi;
+    private const Double gibi = kibi * mebi;
+
+    [Fact]
+    public void BitToString() => FormattingMatches(v => Data.Metric<Bit>(v), "bit");
+    [Fact]
+    public void ByteToString() => FormattingMatches(v => Data.Metric<Bytes>(v), "B");
+    [Fact]
+    public void NibbleToString() => FormattingMatches(v => Data.Metric<Nibble>(v), "N");
+    [Fact]
+    public void KibiBitToString() => FormattingMatches(v => Data.Metric<Kibi, Bit>(v), "Kibit");
+    [Fact]
+    public void KiloBitToString() => FormattingMatches(v => Data.Metric<Kilo, Bit>(v), "Kbit");
+    [Fact]
+    public void KiloByteToString() => FormattingMatches(v => Data.Metric<Kilo, Bytes>(v), "KB");
+    [Fact]
+    public void KibiByteToString() => FormattingMatches(v => Data.Metric<Kibi, Bytes>(v), "KiB");
+    [Fact]
+    public void DefinitionOfNibble()
+    {
+        Data definition = Data.Metric<Bit>(4);
+        Data oneNibble = Data.Metric<Nibble>(1);
+
+        Assert.Equal(definition, oneNibble);
+    }
+    [Fact]
+    public void DefinitionOfByte()
+    {
+        Data definition = Data.Metric<Bit>(8);
+        Data oneByte = Data.Metric<Bytes>(1);
+
+        Assert.Equal(definition, oneByte);
+    }
+    [Fact]
+    public void DefinitionOfKiloByte()
+    {
+        Data definition = Data.Metric<Bit>(8 * 1000);
+        Data oneByte = Data.Metric<Kilo, Bytes>(1);
+
+        Assert.Equal(definition, oneByte);
+    }
+    [Fact]
+    public void DefinitionOfKibiByte()
+    {
+        Data definition = Data.Metric<Bit>(8 * kibi);
+        Data oneByte = Data.Metric<Kibi, Bytes>(1);
+
+        Assert.Equal(definition, oneByte);
+    }
+    [Fact]
+    public void MebiByteToMegaByte()
+    {
+        Data expected = Data.Metric<Mega, Bytes>(3 * mebi / 1e6);
+        Data mebiBytes = Data.Metric<Mebi, Bytes>(3);
+
+        Data actual = mebiBytes.ToMetric<Mega, Bytes>();
+
+        actual.Matches(expected);
+    }
+    [Fact]
+    public void GigaByteToGibiByte()
+    {
+        Data expected = Data.Metric<Gibi, Bytes>(22 * 1e9 / gibi);
+        Data mebiBytes = Data.Metric<Giga, Bytes>(22);
+
+        Data actual = mebiBytes.ToMetric<Gibi, Bytes>();
+
+        actual.Matches(expected);
+    }
+}

--- a/quantities.test/LengthTest.cs
+++ b/quantities.test/LengthTest.cs
@@ -4,7 +4,8 @@ namespace Quantities.Test;
 
 public sealed class LengthTest
 {
-    private const Double KILOMETRE_IN_MILES = 1d / 1.609344d;
+    private const Double MILES_IN_KILOMETRE = 1.609344d;
+    private const Double KILOMETRE_IN_MILES = 1d / MILES_IN_KILOMETRE;
 
     [Fact]
     public void MetreToKilometre()
@@ -169,6 +170,18 @@ public sealed class LengthTest
         Velocity expected = Velocity.Imperial<Mile>(35).Per<Hour>();
 
         Velocity actual = distance / duration;
+
+        actual.Matches(expected);
+    }
+    [Fact]
+    public void VelocityTimesTimeIsLength()
+    {
+        Time duration = Time.In<Minute>(12);
+        Velocity velocity = Velocity.Imperial<Mile>(350).Per<Hour>();
+        // Miles are not yet preserved across multiplication...
+        Length expected = Length.Si<Kilo, Metre>(350 * 12 * MILES_IN_KILOMETRE / 60);
+
+        Length actual = velocity * duration;
 
         actual.Matches(expected);
     }

--- a/quantities.test/LengthTest.cs
+++ b/quantities.test/LengthTest.cs
@@ -11,7 +11,7 @@ public sealed class LengthTest
     {
         Length metres = Length.Si<Metre>(1000);
         Length kilometres = metres.To<Kilo, Metre>();
-        Assert.Equal(1d, kilometres, SiPrecision);
+        PrecisionIsBounded(1d, kilometres);
     }
 
     [Fact]
@@ -19,7 +19,7 @@ public sealed class LengthTest
     {
         Length metres = Length.Si<Metre>(1);
         Length millimetres = metres.To<Milli, Metre>();
-        Assert.Equal(1000d, millimetres, SiPrecision);
+        PrecisionIsBounded(1000d, millimetres);
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public sealed class LengthTest
     {
         Length millimetres = Length.Si<Milli, Metre>(2e6);
         Length kilometres = millimetres.To<Kilo, Metre>();
-        Assert.Equal(2d, kilometres, SiPrecision);
+        PrecisionIsBounded(2d, kilometres);
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class LengthTest
     {
         Length miles = Length.Imperial<Mile>(1);
         Length kilometres = miles.To<Kilo, Metre>();
-        Assert.Equal(1.609344, kilometres, SiPrecision);
+        PrecisionIsBounded(1.609344, kilometres);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public sealed class LengthTest
     {
         Length kilometres = Length.Si<Kilo, Metre>(1.609344);
         Length miles = kilometres.ToImperial<Mile>();
-        Assert.Equal(1d, miles, SiPrecision);
+        PrecisionIsBounded(1d, miles);
     }
     [Fact]
     public void FootToMile()
@@ -60,7 +60,7 @@ public sealed class LengthTest
         Length kilometres = Length.Si<Kilo, Metre>(10);
         Length metres = Length.Si<Metre>(20);
         Length result = kilometres + metres;
-        Assert.Equal(10.02, result, SiPrecision);
+        PrecisionIsBounded(10.02, result);
     }
     [Fact]
     public void AddKilometresToMiles()
@@ -68,7 +68,7 @@ public sealed class LengthTest
         Length kilometres = Length.Si<Kilo, Metre>(1);
         Length miles = Length.Imperial<Mile>(1);
         Length result = miles + kilometres;
-        Assert.Equal(1 + KILOMETRE_IN_MILES, result, SiPrecision);
+        PrecisionIsBounded(1 + KILOMETRE_IN_MILES, result);
     }
     [Fact]
     public void AddMilesToKilometres()
@@ -76,7 +76,7 @@ public sealed class LengthTest
         Length kilometres = Length.Si<Kilo, Metre>(1);
         Length miles = Length.Imperial<Mile>(1);
         Length result = kilometres + miles;
-        Assert.Equal(2.609344, result, SiPrecision);
+        PrecisionIsBounded(2.609344, result);
     }
     [Fact]
     public void SubtractKilometresFromMetres()
@@ -84,7 +84,7 @@ public sealed class LengthTest
         Length metres = Length.Si<Metre>(2000);
         Length kilometres = Length.Si<Kilo, Metre>(0.5);
         Length result = metres - kilometres;
-        Assert.Equal(1500d, result, SiPrecision);
+        PrecisionIsBounded(1500d, result);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public sealed class LengthTest
         Length kilometres = Length.Si<Kilo, Metre>(2.609344);
         Length miles = Length.Imperial<Mile>(1);
         Length result = kilometres - miles;
-        Assert.Equal(1d, result, SiPrecision);
+        PrecisionIsBounded(1d, result);
     }
     [Fact]
     public void OneMileInYards()

--- a/quantities.test/MassTest.cs
+++ b/quantities.test/MassTest.cs
@@ -98,7 +98,7 @@ public sealed class MassTest
 
         Mass actual = mass.ToImperial<Pound>();
 
-        actual.Matches(expected);
+        actual.Matches(expected, MediumPrecision);
     }
     [Fact]
     public void PoundToGram()

--- a/quantities.test/TemperatureTest.cs
+++ b/quantities.test/TemperatureTest.cs
@@ -6,7 +6,6 @@ namespace Quantities.Test;
 // For a lot of the values here, see: https://en.wikipedia.org/wiki/Conversion_of_units_of_temperature#Comparison_of_temperature_scales
 public sealed class TemperatureTest
 {
-    private static readonly Int32 imperialTemperaturePrecision = ImperialPrecision - 1;
     [Fact]
     public void KelvinToString() => FormattingMatches(v => Temperature.Si<Kelvin>(v), "K");
     [Fact]
@@ -117,7 +116,7 @@ public sealed class TemperatureTest
 
         Temperature actual = temperature.ToImperial<GasMark>();
 
-        actual.Matches(expected, imperialTemperaturePrecision);
+        actual.Matches(expected, VeryLowPrecision);
     }
 
     [Fact]
@@ -128,7 +127,7 @@ public sealed class TemperatureTest
 
         Temperature actual = temperature.ToImperial<GasMark>();
 
-        actual.Matches(expected, imperialTemperaturePrecision);
+        actual.Matches(expected, VeryLowPrecision);
     }
     [Fact]
     public void GasMarkToFahrenheit()

--- a/quantities.test/VolumeTest.cs
+++ b/quantities.test/VolumeTest.cs
@@ -11,7 +11,7 @@ public sealed class VolumeTest
         Volume left = Volume.Cubic<Metre>(20);
         Volume right = Volume.Cubic<Metre>(10);
         Volume result = left + right;
-        Assert.Equal(30d, result, SiPrecision);
+        PrecisionIsBounded(30d, result);
     }
     [Fact]
     public void FromSiToLitre()

--- a/quantities.test/prefixes/BinaryPrefixTest.cs
+++ b/quantities.test/prefixes/BinaryPrefixTest.cs
@@ -1,0 +1,73 @@
+namespace Quantities.Test.Prefixes;
+
+public class BinaryPrefixTest
+{
+    private static readonly IPrefixInject<Double> injector = new GetValue();
+
+    [Theory]
+    [MemberData(nameof(BinaryMaxValues))]
+    public void ScaleSiPrefixes(Double valueToNormalize)
+    {
+        Double actualValue = BinaryPrefix.Scale(valueToNormalize, injector);
+
+        PrecisionIsBounded(1d, actualValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryMaxValues))]
+    public void ScalesAllValuesWithinOneAndThousand(Double value)
+    {
+        var seed = Math.Sqrt(2) * Math.E / (2d * Math.E);
+        var range = new Double[] { (1d + Math.Pow(16, -12)) / seed, 2, 4, 5, 6, 8, 9 }.Select(r => seed * r).ToArray();
+        var inputValues = Enumerable.Range(0, 3).SelectMany(e => range.Select(r => r * value * Math.Pow(10, e))).ToArray();
+
+        var actual = inputValues.Select(v => BinaryPrefix.Scale(v, injector)).ToArray();
+
+        Assert.All(actual, a => Assert.InRange(a, 1d, 1000d));
+    }
+
+    [Theory]
+    [MemberData(nameof(VeryLargeMaxValues))]
+    public void ScaleVeryLargeValues(Double valueToNormalize)
+    {
+        Double expectedValue = Normalize<Yobi>(valueToNormalize);
+        Double actualValue = BinaryPrefix.Scale(valueToNormalize, injector);
+
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    public static IEnumerable<Object[]> BinaryMaxValues()
+    {
+        return AllBinaryMaxValues().Select(i => new Object[] { i });
+    }
+
+    public static IEnumerable<Object[]> VeryLargeMaxValues()
+    {
+        Double quettaMaxValue = MaxValue<Yobi>();
+        return Enumerable.Range(0, 5).Select(e => new Object[] { Math.Pow(16, e) * quettaMaxValue });
+    }
+
+    private static IEnumerable<Double> AllBinaryMaxValues()
+    {
+        yield return MaxValue<Yobi>();
+        yield return MaxValue<Zebi>();
+        yield return MaxValue<Exbi>();
+        yield return MaxValue<Pebi>();
+        yield return MaxValue<Tebi>();
+        yield return MaxValue<Gibi>();
+        yield return MaxValue<Mebi>();
+        yield return MaxValue<Kibi>();
+        yield return 1d; // unit prefix
+    }
+
+    private static Double MaxValue<TPrefix>()
+        where TPrefix : IBinaryPrefix => TPrefix.ToSi(1d);
+    private static Double Normalize<TPrefix>(Double value)
+        where TPrefix : IBinaryPrefix => TPrefix.FromSi(in value);
+
+    private sealed class GetValue : IPrefixInject<Double>
+    {
+        public Double Identity(in Double value) => value;
+        public Double Inject<TPrefix>(in Double value) where TPrefix : IPrefix => value;
+    }
+}

--- a/quantities.test/prefixes/BinaryPrefixesTest.cs
+++ b/quantities.test/prefixes/BinaryPrefixesTest.cs
@@ -1,0 +1,39 @@
+namespace Quantities.Test.Prefixes;
+
+public class BinaryPrefixesTest
+{
+    private static readonly PrefixTests tests = new(precision: 16);
+    [Theory]
+    [MemberData(nameof(AllBinaryPrefixes))]
+    public void ToSiScalesAsExpected(ITestPrefix prefix) => tests.ToSiScalesAsExpected(prefix);
+
+    [Theory]
+    [MemberData(nameof(AllBinaryPrefixes))]
+    public void FromSiScalesAsExpected(ITestPrefix prefix) => tests.FromSiScalesAsExpected(prefix);
+
+    [Theory]
+    [MemberData(nameof(AllBinaryPrefixes))]
+    public void ToSiRoundRobinEquality(ITestPrefix prefix) => tests.ToSiRoundRobinEquality(prefix);
+
+    [Theory]
+    [MemberData(nameof(AllBinaryPrefixes))]
+    public void FromSiRoundRobinEquality(ITestPrefix prefix) => tests.FromSiRoundRobinEquality(prefix);
+    public static IEnumerable<Object[]> AllBinaryPrefixes()
+    {
+        return BinaryPrefixes().Select(p => new Object[] { p });
+    }
+    public static IEnumerable<ITestPrefix> BinaryPrefixes()
+    {
+        const Double kibi = 1024;
+        const Double gibi = 1073741824;
+        const Double tebi = 1099511627776;
+        yield return new TestPrefix<Kibi>(kibi);
+        yield return new TestPrefix<Mebi>(kibi * kibi);
+        yield return new TestPrefix<Gibi>(gibi);
+        yield return new TestPrefix<Tebi>(tebi);
+        yield return new TestPrefix<Pebi>(kibi * tebi);
+        yield return new TestPrefix<Exbi>(gibi * gibi);
+        yield return new TestPrefix<Zebi>(gibi * tebi);
+        yield return new TestPrefix<Yobi>(tebi * tebi);
+    }
+}

--- a/quantities.test/prefixes/BinaryPrefixesTest.cs
+++ b/quantities.test/prefixes/BinaryPrefixesTest.cs
@@ -2,22 +2,21 @@ namespace Quantities.Test.Prefixes;
 
 public class BinaryPrefixesTest
 {
-    private static readonly PrefixTests tests = new(precision: 16);
     [Theory]
     [MemberData(nameof(AllBinaryPrefixes))]
-    public void ToSiScalesAsExpected(ITestPrefix prefix) => tests.ToSiScalesAsExpected(prefix);
+    public void ToSiScalesAsExpected(ITestPrefix prefix) => PrefixTests.ToSiScalesAsExpected(prefix, FullPrecision);
 
     [Theory]
     [MemberData(nameof(AllBinaryPrefixes))]
-    public void FromSiScalesAsExpected(ITestPrefix prefix) => tests.FromSiScalesAsExpected(prefix);
+    public void FromSiScalesAsExpected(ITestPrefix prefix) => PrefixTests.FromSiScalesAsExpected(prefix, FullPrecision);
 
     [Theory]
     [MemberData(nameof(AllBinaryPrefixes))]
-    public void ToSiRoundRobinEquality(ITestPrefix prefix) => tests.ToSiRoundRobinEquality(prefix);
+    public void ToSiRoundRobinEquality(ITestPrefix prefix) => PrefixTests.ToSiRoundRobinEquality(prefix, FullPrecision);
 
     [Theory]
     [MemberData(nameof(AllBinaryPrefixes))]
-    public void FromSiRoundRobinEquality(ITestPrefix prefix) => tests.FromSiRoundRobinEquality(prefix);
+    public void FromSiRoundRobinEquality(ITestPrefix prefix) => PrefixTests.FromSiRoundRobinEquality(prefix, FullPrecision);
     public static IEnumerable<Object[]> AllBinaryPrefixes()
     {
         return BinaryPrefixes().Select(p => new Object[] { p });

--- a/quantities.test/prefixes/MetricPrefixTest.cs
+++ b/quantities.test/prefixes/MetricPrefixTest.cs
@@ -1,6 +1,6 @@
 namespace Quantities.Test.Prefixes;
 
-public class SiPrefixTest
+public class MetricPrefixTest
 {
     private const Int32 precision = 12;
     private static readonly IPrefixInject<Double> injector = new GetValue();

--- a/quantities.test/prefixes/MetricPrefixesTest.cs
+++ b/quantities.test/prefixes/MetricPrefixesTest.cs
@@ -2,7 +2,7 @@ using Xunit.Sdk;
 
 namespace Quantities.Test.Prefixes;
 
-public class SiPrefixesTest
+public class MetricPrefixesTest
 {
     private const Int32 fullPrecision = 16;
     private const Int32 mediumPrecision = fullPrecision - 1;

--- a/quantities.test/prefixes/MetricPrefixesTest.cs
+++ b/quantities.test/prefixes/MetricPrefixesTest.cs
@@ -65,6 +65,8 @@ public class MetricPrefixesTest
     public static IEnumerable<Object[]> AllMetricPrefixes() => MetricPrefixes().Select(p => new Object[] { p });
     public static IEnumerable<ITestPrefix> MetricPrefixes()
     {
+        // Excluding prefixes that cannot round exactly.
+        // They are covered with the "outlier" tests.
         yield return new TestPrefix<Ronna>(1e27);
         yield return new TestPrefix<Yotta>(1e24);
         yield return new TestPrefix<Exa>(1e18);

--- a/quantities.test/prefixes/PrefixTests.cs
+++ b/quantities.test/prefixes/PrefixTests.cs
@@ -1,43 +1,40 @@
 namespace Quantities.Test.Prefixes;
 
-internal sealed class PrefixTests
+internal static class PrefixTests
 {
-    private readonly Int32 precision;
-    public PrefixTests(Int32 precision) => this.precision = precision;
-
-    public void ToSiScalesAsExpected(ITestPrefix prefix)
+    public static void ToSiScalesAsExpected(ITestPrefix prefix, Int32 precision)
     {
         Double scalingFactor = prefix.ToSi(1d);
         Double normalisedFactor = scalingFactor / prefix.Factor;
 
-        PrecisionIsBounded(1d, normalisedFactor, this.precision);
+        PrecisionIsBounded(1d, normalisedFactor, precision);
     }
 
-    public void FromSiScalesAsExpected(ITestPrefix prefix)
+    public static void FromSiScalesAsExpected(ITestPrefix prefix, Int32 precision)
     {
         Double scalingFactor = prefix.FromSi(1d);
         Double normalisedFactor = scalingFactor * prefix.Factor;
 
-        PrecisionIsBounded(1d, normalisedFactor, this.precision);
+        PrecisionIsBounded(1d, normalisedFactor, precision);
     }
 
-    public void ToSiRoundRobinEquality(ITestPrefix prefix)
+    public static void ToSiRoundRobinEquality(ITestPrefix prefix, Int32 precision)
     {
         const Double expected = 2d;
 
         Double siValue = prefix.ToSi(expected);
         Double actual = prefix.FromSi(siValue);
 
-        PrecisionIsBounded(expected, actual, this.precision);
+        PrecisionIsBounded(expected, actual, precision);
     }
 
-    public void FromSiRoundRobinEquality(ITestPrefix prefix)
+    public static void FromSiRoundRobinEquality(ITestPrefix prefix, Int32 precision)
     {
         const Double expected = 2d;
 
         Double siValue = prefix.FromSi(expected);
         Double actual = prefix.ToSi(siValue);
 
-        PrecisionIsBounded(expected, actual, this.precision);
+        PrecisionIsBounded(expected, actual, precision);
     }
 }

--- a/quantities.test/prefixes/PrefixTests.cs
+++ b/quantities.test/prefixes/PrefixTests.cs
@@ -1,0 +1,43 @@
+namespace Quantities.Test.Prefixes;
+
+internal sealed class PrefixTests
+{
+    private readonly Int32 precision;
+    public PrefixTests(Int32 precision) => this.precision = precision;
+
+    public void ToSiScalesAsExpected(ITestPrefix prefix)
+    {
+        Double scalingFactor = prefix.ToSi(1d);
+        Double normalisedFactor = scalingFactor / prefix.Factor;
+
+        PrecisionIsBounded(1d, normalisedFactor, this.precision);
+    }
+
+    public void FromSiScalesAsExpected(ITestPrefix prefix)
+    {
+        Double scalingFactor = prefix.FromSi(1d);
+        Double normalisedFactor = scalingFactor * prefix.Factor;
+
+        PrecisionIsBounded(1d, normalisedFactor, this.precision);
+    }
+
+    public void ToSiRoundRobinEquality(ITestPrefix prefix)
+    {
+        const Double expected = 2d;
+
+        Double siValue = prefix.ToSi(expected);
+        Double actual = prefix.FromSi(siValue);
+
+        PrecisionIsBounded(expected, actual, this.precision);
+    }
+
+    public void FromSiRoundRobinEquality(ITestPrefix prefix)
+    {
+        const Double expected = 2d;
+
+        Double siValue = prefix.FromSi(expected);
+        Double actual = prefix.ToSi(siValue);
+
+        PrecisionIsBounded(expected, actual, this.precision);
+    }
+}

--- a/quantities.test/prefixes/SiPrefixTest.cs
+++ b/quantities.test/prefixes/SiPrefixTest.cs
@@ -147,9 +147,9 @@ public class SiPrefixTest
     }
 
     private static Double MaxValue<TPrefix>()
-        where TPrefix : IPrefix => TPrefix.ToSi(1d);
+        where TPrefix : ISiPrefix => TPrefix.ToSi(1d);
     private static Double Normalize<TPrefix>(Double value)
-        where TPrefix : IPrefix => TPrefix.FromSi(in value);
+        where TPrefix : ISiPrefix => TPrefix.FromSi(in value);
 
     private sealed class GetValue : IPrefixInject<Double>
     {

--- a/quantities.test/prefixes/SiPrefixTest.cs
+++ b/quantities.test/prefixes/SiPrefixTest.cs
@@ -131,7 +131,7 @@ public class SiPrefixTest
         yield return MaxValue<Kilo>();
         yield return MaxValue<Hecto>();
         yield return MaxValue<Deca>();
-        yield return MaxValue<UnitPrefix>();
+        yield return 1d; // unit prefix
         yield return MaxValue<Deci>();
         yield return MaxValue<Centi>();
         yield return MaxValue<Milli>();

--- a/quantities.test/prefixes/SiPrefixTest.cs
+++ b/quantities.test/prefixes/SiPrefixTest.cs
@@ -11,7 +11,7 @@ public class SiPrefixTest
     [InlineData(968)]
     public void ScaleThreeSkipsExponentsSmallerThanKilo(Double value)
     {
-        Double actualValue = SiPrefix.ScaleThree(value, injector);
+        Double actualValue = MetricPrefix.ScaleThree(value, injector);
         Assert.Equal(value, actualValue);
     }
 
@@ -22,7 +22,7 @@ public class SiPrefixTest
     public void ScaleThreeSkipsExponentsLargerThanMilli(Double value)
     {
         // Everything usually scaled to deci ot centi should be milli!
-        Double actualValue = SiPrefix.ScaleThree(value, injector);
+        Double actualValue = MetricPrefix.ScaleThree(value, injector);
         Assert.Equal(value * 1e3, actualValue);
     }
 
@@ -30,7 +30,7 @@ public class SiPrefixTest
     [MemberData(nameof(SiMaxValues))]
     public void ScaleSiPrefixes(Double valueToNormalize)
     {
-        Double actualValue = SiPrefix.Scale(valueToNormalize, injector);
+        Double actualValue = MetricPrefix.Scale(valueToNormalize, injector);
 
         Assert.Equal(1d, actualValue, precision);
     }
@@ -42,7 +42,7 @@ public class SiPrefixTest
         var range = new Double[] { (1d + Math.Pow(10, -12)) / seed, 2, 4, 5, 6, 8, 9 }.Select(r => seed * r).ToArray();
         var inputValues = Enumerable.Range(0, 3).SelectMany(e => range.Select(r => r * value * Math.Pow(10, e))).ToArray();
 
-        var actual = inputValues.Select(v => SiPrefix.Scale(v, injector)).ToArray();
+        var actual = inputValues.Select(v => MetricPrefix.Scale(v, injector)).ToArray();
 
         Assert.All(actual, a => Assert.InRange(a, 1d, 1000d));
     }
@@ -53,7 +53,7 @@ public class SiPrefixTest
     {
         Double[] expectedValues = new[] { -3.8, 78, -647 };
         var valuesToNormalize = expectedValues.Select(e => value * e).ToArray();
-        var actualValues = valuesToNormalize.Select(v => SiPrefix.Scale(v, injector)).ToArray();
+        var actualValues = valuesToNormalize.Select(v => MetricPrefix.Scale(v, injector)).ToArray();
 
         Assert.All(expectedValues.Zip(actualValues, (e, a) => (e, a)), c => Assert.Equal(c.e, c.a, precision));
     }
@@ -64,7 +64,7 @@ public class SiPrefixTest
     {
         Double[] expectedValues = new[] { 1.2, -18, 243 };
         var valuesToNormalize = expectedValues.Select(e => value * e).ToArray();
-        var actualValues = valuesToNormalize.Select(v => SiPrefix.Scale(v, injector)).ToArray();
+        var actualValues = valuesToNormalize.Select(v => MetricPrefix.Scale(v, injector)).ToArray();
 
         Assert.All(expectedValues.Zip(actualValues, (e, a) => (e, a)), c => Assert.Equal(c.e, c.a, precision));
     }
@@ -74,7 +74,7 @@ public class SiPrefixTest
     public void ScaleVerySmallValues(Double valueToNormalize)
     {
         Double expectedValue = Normalize<Quecto>(valueToNormalize);
-        Double actualValue = SiPrefix.Scale(valueToNormalize, injector);
+        Double actualValue = MetricPrefix.Scale(valueToNormalize, injector);
 
         Assert.Equal(expectedValue, actualValue);
     }
@@ -84,7 +84,7 @@ public class SiPrefixTest
     public void ScaleVeryLargeValues(Double valueToNormalize)
     {
         Double expectedValue = Normalize<Quetta>(valueToNormalize);
-        Double actualValue = SiPrefix.Scale(valueToNormalize, injector);
+        Double actualValue = MetricPrefix.Scale(valueToNormalize, injector);
 
         Assert.Equal(expectedValue, actualValue);
     }
@@ -147,9 +147,9 @@ public class SiPrefixTest
     }
 
     private static Double MaxValue<TPrefix>()
-        where TPrefix : ISiPrefix => TPrefix.ToSi(1d);
+        where TPrefix : IMetricPrefix => TPrefix.ToSi(1d);
     private static Double Normalize<TPrefix>(Double value)
-        where TPrefix : ISiPrefix => TPrefix.FromSi(in value);
+        where TPrefix : IMetricPrefix => TPrefix.FromSi(in value);
 
     private sealed class GetValue : IPrefixInject<Double>
     {

--- a/quantities.test/prefixes/SiPrefixTest.cs
+++ b/quantities.test/prefixes/SiPrefixTest.cs
@@ -32,7 +32,7 @@ public class SiPrefixTest
     {
         Double actualValue = MetricPrefix.Scale(valueToNormalize, injector);
 
-        Assert.Equal(1d, actualValue, precision);
+        Assert.Equal(1d, actualValue, MediumPrecision);
     }
     [Theory]
     [MemberData(nameof(SiMaxValues))]
@@ -66,7 +66,7 @@ public class SiPrefixTest
         var valuesToNormalize = expectedValues.Select(e => value * e).ToArray();
         var actualValues = valuesToNormalize.Select(v => MetricPrefix.Scale(v, injector)).ToArray();
 
-        Assert.All(expectedValues.Zip(actualValues, (e, a) => (e, a)), c => Assert.Equal(c.e, c.a, precision));
+        Assert.All(expectedValues.Zip(actualValues, (e, a) => (e, a)), c => Assert.Equal(c.e, c.a));
     }
 
     [Theory]

--- a/quantities.test/prefixes/SiPrefixesTest.cs
+++ b/quantities.test/prefixes/SiPrefixesTest.cs
@@ -1,0 +1,52 @@
+namespace Quantities.Test.Prefixes;
+
+public class SiPrefixesTest
+{
+    private static readonly PrefixTests tests = new(precision: 15);
+    [Theory]
+    [MemberData(nameof(AllMetricPrefixes))]
+    public void ToSiScalesAsExpected(ITestPrefix prefix) => tests.ToSiScalesAsExpected(prefix);
+
+    [Theory]
+    [MemberData(nameof(AllMetricPrefixes))]
+    public void FromSiScalesAsExpected(ITestPrefix prefix) => tests.FromSiScalesAsExpected(prefix);
+
+    [Theory]
+    [MemberData(nameof(AllMetricPrefixes))]
+    public void ToSiRoundRobinEquality(ITestPrefix prefix) => tests.ToSiRoundRobinEquality(prefix);
+
+    [Theory]
+    [MemberData(nameof(AllMetricPrefixes))]
+    public void FromSiRoundRobinEquality(ITestPrefix prefix) => tests.FromSiRoundRobinEquality(prefix);
+    public static IEnumerable<Object[]> AllMetricPrefixes()
+    {
+        return MetricPrefixes().Select(p => new Object[] { p });
+    }
+    public static IEnumerable<ITestPrefix> MetricPrefixes()
+    {
+        yield return new TestPrefix<Quetta>(1e30);
+        yield return new TestPrefix<Ronna>(1e27);
+        yield return new TestPrefix<Yotta>(1e24);
+        yield return new TestPrefix<Zetta>(1e21);
+        yield return new TestPrefix<Exa>(1e18);
+        yield return new TestPrefix<Peta>(1e15);
+        yield return new TestPrefix<Tera>(1e12);
+        yield return new TestPrefix<Giga>(1e9);
+        yield return new TestPrefix<Mega>(1e6);
+        yield return new TestPrefix<Kilo>(1e3);
+        yield return new TestPrefix<Hecto>(1e2);
+        yield return new TestPrefix<Deca>(1e1);
+        yield return new TestPrefix<Deci>(1e-1);
+        yield return new TestPrefix<Centi>(1e-2);
+        yield return new TestPrefix<Milli>(1e-3);
+        yield return new TestPrefix<Micro>(1e-6);
+        yield return new TestPrefix<Nano>(1e-9);
+        yield return new TestPrefix<Pico>(1e-12);
+        yield return new TestPrefix<Femto>(1e-15);
+        yield return new TestPrefix<Atto>(1e-18);
+        yield return new TestPrefix<Zepto>(1e-21);
+        yield return new TestPrefix<Yocto>(1e-24);
+        yield return new TestPrefix<Ronto>(1e-27);
+        yield return new TestPrefix<Quecto>(1e-30);
+    }
+}

--- a/quantities.test/prefixes/SiPrefixesTest.cs
+++ b/quantities.test/prefixes/SiPrefixesTest.cs
@@ -1,33 +1,72 @@
+using Xunit.Sdk;
+
 namespace Quantities.Test.Prefixes;
 
 public class SiPrefixesTest
 {
-    private static readonly PrefixTests tests = new(precision: 15);
-    [Theory]
-    [MemberData(nameof(AllMetricPrefixes))]
-    public void ToSiScalesAsExpected(ITestPrefix prefix) => tests.ToSiScalesAsExpected(prefix);
+    private const Int32 fullPrecision = 16;
+    private const Int32 mediumPrecision = fullPrecision - 1;
+    private static readonly Dictionary<String, ITestPrefix> outliers = new() {
+        ["quetta"] = new TestPrefix<Quetta>(1e30),
+        ["zetta"] = new TestPrefix<Zetta>(1e21),
+        ["zepto"] = new TestPrefix<Zepto>(1e-21),
+        ["yocto"] = new TestPrefix<Yocto>(1e-24),
+        ["quecto"] = new TestPrefix<Quecto>(1e-30)
+    };
 
     [Theory]
     [MemberData(nameof(AllMetricPrefixes))]
-    public void FromSiScalesAsExpected(ITestPrefix prefix) => tests.FromSiScalesAsExpected(prefix);
+    public void ToSiScalesAsExpected(ITestPrefix prefix) => PrefixTests.ToSiScalesAsExpected(prefix, FullPrecision);
+
+    [Theory]
+    [InlineData("quetta", fullPrecision)]
+    [InlineData("zetta", fullPrecision)]
+    [InlineData("zepto", fullPrecision)]
+    [InlineData("yocto", mediumPrecision)]
+    [InlineData("quecto", mediumPrecision)]
+    public void ToSiScalesAsExpected_VariablePrecision(String prefix, Int32 precision) => PrefixTests.ToSiScalesAsExpected(outliers[prefix], precision);
 
     [Theory]
     [MemberData(nameof(AllMetricPrefixes))]
-    public void ToSiRoundRobinEquality(ITestPrefix prefix) => tests.ToSiRoundRobinEquality(prefix);
+    public void FromSiScalesAsExpected(ITestPrefix prefix) => PrefixTests.FromSiScalesAsExpected(prefix, FullPrecision);
+
+    [Theory]
+    [InlineData("quetta", mediumPrecision)]
+    [InlineData("zetta", mediumPrecision)]
+    [InlineData("zepto", mediumPrecision)]
+    [InlineData("yocto", mediumPrecision)]
+    [InlineData("quecto", fullPrecision)]
+    public void FromSiScalesAsExpected_VariablePrecision(String prefix, Int32 precision) => PrefixTests.FromSiScalesAsExpected(outliers[prefix], precision);
 
     [Theory]
     [MemberData(nameof(AllMetricPrefixes))]
-    public void FromSiRoundRobinEquality(ITestPrefix prefix) => tests.FromSiRoundRobinEquality(prefix);
-    public static IEnumerable<Object[]> AllMetricPrefixes()
-    {
-        return MetricPrefixes().Select(p => new Object[] { p });
-    }
+    public void ToSiRoundRobinEquality(ITestPrefix prefix) => PrefixTests.ToSiRoundRobinEquality(prefix, FullPrecision);
+
+    [Theory]
+    [InlineData("quetta", fullPrecision)]
+    [InlineData("zetta", fullPrecision)]
+    [InlineData("zepto", mediumPrecision)]
+    [InlineData("yocto", fullPrecision)]
+    [InlineData("quecto", mediumPrecision)]
+    public void ToSiRoundRobinEquality_VariablePrecision(String prefix, Int32 precision) => PrefixTests.ToSiRoundRobinEquality(outliers[prefix], precision);
+
+    [Theory]
+    [MemberData(nameof(AllMetricPrefixes))]
+    public void FromSiRoundRobinEquality(ITestPrefix prefix) => PrefixTests.FromSiRoundRobinEquality(prefix, FullPrecision);
+
+    [Theory]
+    [InlineData("quetta", mediumPrecision)]
+    [InlineData("zetta", mediumPrecision)]
+    [InlineData("zepto", fullPrecision)]
+    [InlineData("yocto", fullPrecision)]
+    [InlineData("quecto", fullPrecision)]
+    public void FromSiRoundRobinEquality_VariablePrecision(String prefix, Int32 precision) => PrefixTests.FromSiRoundRobinEquality(outliers[prefix], precision);
+
+    public static IEnumerable<Object[]> AllMetricPrefixes() => MetricPrefixes().Select(p => new Object[] { p });
     public static IEnumerable<ITestPrefix> MetricPrefixes()
     {
-        yield return new TestPrefix<Quetta>(1e30);
         yield return new TestPrefix<Ronna>(1e27);
         yield return new TestPrefix<Yotta>(1e24);
-        yield return new TestPrefix<Zetta>(1e21);
         yield return new TestPrefix<Exa>(1e18);
         yield return new TestPrefix<Peta>(1e15);
         yield return new TestPrefix<Tera>(1e12);
@@ -44,9 +83,6 @@ public class SiPrefixesTest
         yield return new TestPrefix<Pico>(1e-12);
         yield return new TestPrefix<Femto>(1e-15);
         yield return new TestPrefix<Atto>(1e-18);
-        yield return new TestPrefix<Zepto>(1e-21);
-        yield return new TestPrefix<Yocto>(1e-24);
         yield return new TestPrefix<Ronto>(1e-27);
-        yield return new TestPrefix<Quecto>(1e-30);
     }
 }

--- a/quantities.test/prefixes/TestPrefix.cs
+++ b/quantities.test/prefixes/TestPrefix.cs
@@ -1,0 +1,19 @@
+namespace Quantities.Test.Prefixes;
+
+public interface ITestPrefix
+{
+    Double Factor { get; }
+    Double ToSi(Double value);
+    Double FromSi(Double value);
+}
+
+public sealed class TestPrefix<TPrefix> : ITestPrefix
+    where TPrefix : IPrefix
+{
+    public Double Factor { get; }
+    public TestPrefix(Double factor = Double.NaN) => Factor = Double.IsNaN(factor) ? TPrefix.ToSi(1d) : factor;
+    public Double ToSi(Double value) => TPrefix.ToSi(in value);
+    public Double FromSi(Double value) => TPrefix.FromSi(in value);
+
+    public override String ToString() => TPrefix.Representation;
+}

--- a/quantities/Extensions.cs
+++ b/quantities/Extensions.cs
@@ -15,6 +15,12 @@ public static class Extensions
        where TPrefix : ISiPrefix, IScaleDown
        where TUnit : ISiBaseUnit, ITime => new(builder.By<Si<TPrefix, TUnit>>());
     public static Velocity PerSecond(this IBuilder<Velocity> builder) => new(builder.By<Si<Second>>());
+    public static DataRate Per<TUnit>(this IBuilder<DataRate> builder)
+       where TUnit : IMetricUnit, ITime => new(builder.By<Metric<TUnit>>());
+    public static DataRate Per<TPrefix, TUnit>(this IBuilder<DataRate> builder)
+       where TPrefix : ISiPrefix, IScaleDown
+       where TUnit : ISiBaseUnit, ITime => new(builder.By<Si<TPrefix, TUnit>>());
+    public static DataRate PerSecond(this IBuilder<DataRate> builder) => new(builder.By<Si<Second>>());
     internal static Quant To<TDim, TMeasure>(this Double value)
       where TDim : Measures.IDimension where TMeasure : IMeasure, ILinear
       => Build<Power<TDim, TMeasure>>.With<Linear<TMeasure>>(in value);

--- a/quantities/Extensions.cs
+++ b/quantities/Extensions.cs
@@ -12,13 +12,13 @@ public static class Extensions
     public static Velocity Per<TUnit>(this IBuilder<Velocity> builder)
        where TUnit : IMetricUnit, ITime => new(builder.By<Metric<TUnit>>());
     public static Velocity Per<TPrefix, TUnit>(this IBuilder<Velocity> builder)
-       where TPrefix : ISiPrefix, IScaleDown
+       where TPrefix : IMetricPrefix, IScaleDown
        where TUnit : ISiBaseUnit, ITime => new(builder.By<Si<TPrefix, TUnit>>());
     public static Velocity PerSecond(this IBuilder<Velocity> builder) => new(builder.By<Si<Second>>());
     public static DataRate Per<TUnit>(this IBuilder<DataRate> builder)
        where TUnit : IMetricUnit, ITime => new(builder.By<Metric<TUnit>>());
     public static DataRate Per<TPrefix, TUnit>(this IBuilder<DataRate> builder)
-       where TPrefix : ISiPrefix, IScaleDown
+       where TPrefix : IMetricPrefix, IScaleDown
        where TUnit : ISiBaseUnit, ITime => new(builder.By<Si<TPrefix, TUnit>>());
     public static DataRate PerSecond(this IBuilder<DataRate> builder) => new(builder.By<Si<Second>>());
     internal static Quant To<TDim, TMeasure>(this Double value)

--- a/quantities/Extensions.cs
+++ b/quantities/Extensions.cs
@@ -12,7 +12,7 @@ public static class Extensions
     public static Velocity Per<TUnit>(this IBuilder<Velocity> builder)
        where TUnit : IMetricUnit, ITime => new(builder.By<Metric<TUnit>>());
     public static Velocity Per<TPrefix, TUnit>(this IBuilder<Velocity> builder)
-       where TPrefix : IPrefix, IScaleDown
+       where TPrefix : ISiPrefix, IScaleDown
        where TUnit : ISiBaseUnit, ITime => new(builder.By<Si<TPrefix, TUnit>>());
     public static Velocity PerSecond(this IBuilder<Velocity> builder) => new(builder.By<Si<Second>>());
     internal static Quant To<TDim, TMeasure>(this Double value)

--- a/quantities/IMetric.cs
+++ b/quantities/IMetric.cs
@@ -11,11 +11,11 @@ internal interface IMetric<out TSelf, in TDimension>
     public TSelf ToMetric<TUnit>()
         where TUnit : IMetricUnit, TDimension;
     public TSelf ToMetric<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, TDimension;
     public static abstract TSelf Metric<TUnit>(in Double value)
         where TUnit : IMetricUnit, TDimension;
     public static abstract TSelf Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, TDimension;
 }

--- a/quantities/IMetric.cs
+++ b/quantities/IMetric.cs
@@ -11,11 +11,11 @@ internal interface IMetric<out TSelf, in TDimension>
     public TSelf ToMetric<TUnit>()
         where TUnit : IMetricUnit, TDimension;
     public TSelf ToMetric<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, TDimension;
     public static abstract TSelf Metric<TUnit>(in Double value)
         where TUnit : IMetricUnit, TDimension;
     public static abstract TSelf Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, TDimension;
 }

--- a/quantities/ISi.cs
+++ b/quantities/ISi.cs
@@ -11,12 +11,12 @@ internal interface ISi<out TSelf, in TDimension>
     public TSelf To<TUnit>()
         where TUnit : ISiBaseUnit, TDimension;
     public TSelf To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, TDimension;
     public static abstract TSelf Si<TUnit>(in Double value)
         where TUnit : ISiBaseUnit, TDimension;
     public static abstract TSelf Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, TDimension;
 }
 
@@ -27,11 +27,11 @@ internal interface ISiDerived<out TSelf, in TDimension>
     public TSelf To<TUnit>()
         where TUnit : ISiDerivedUnit, TDimension;
     public TSelf To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, TDimension;
     public static abstract TSelf Si<TUnit>(in Double value)
         where TUnit : ISiDerivedUnit, TDimension;
     public static abstract TSelf Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, TDimension;
 }

--- a/quantities/ISi.cs
+++ b/quantities/ISi.cs
@@ -11,12 +11,12 @@ internal interface ISi<out TSelf, in TDimension>
     public TSelf To<TUnit>()
         where TUnit : ISiBaseUnit, TDimension;
     public TSelf To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, TDimension;
     public static abstract TSelf Si<TUnit>(in Double value)
         where TUnit : ISiBaseUnit, TDimension;
     public static abstract TSelf Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, TDimension;
 }
 
@@ -27,11 +27,11 @@ internal interface ISiDerived<out TSelf, in TDimension>
     public TSelf To<TUnit>()
         where TUnit : ISiDerivedUnit, TDimension;
     public TSelf To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, TDimension;
     public static abstract TSelf Si<TUnit>(in Double value)
         where TUnit : ISiDerivedUnit, TDimension;
     public static abstract TSelf Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, TDimension;
 }

--- a/quantities/dimensions/ElectricalDimesions.cs
+++ b/quantities/dimensions/ElectricalDimesions.cs
@@ -2,3 +2,4 @@
 
 public interface IElectricPotential : IDimension { /* marker interface */ }
 public interface IElectricalResistance : IDimension { /* marker interface */ }
+public interface IAmountOfInformation : IDimension, ILinear { /* marker interface */ }

--- a/quantities/dimensions/ElectricalDimesions.cs
+++ b/quantities/dimensions/ElectricalDimesions.cs
@@ -3,3 +3,4 @@
 public interface IElectricPotential : IDimension { /* marker interface */ }
 public interface IElectricalResistance : IDimension { /* marker interface */ }
 public interface IAmountOfInformation : IDimension, ILinear { /* marker interface */ }
+public interface IInformationRate : IPer<IAmountOfInformation, ITime> { /* marker interface */ }

--- a/quantities/prefixes/BinaryPrefix.cs
+++ b/quantities/prefixes/BinaryPrefix.cs
@@ -1,5 +1,3 @@
-using Quantities.Dimensions;
-using Quantities.Units.Si;
 using static System.Math;
 
 namespace Quantities.Prefixes;

--- a/quantities/prefixes/BinaryPrefix.cs
+++ b/quantities/prefixes/BinaryPrefix.cs
@@ -8,7 +8,7 @@ internal static class BinaryPrefix
 {
     public static T Scale<T>(in Double value, IPrefixInject<T> injector)
     {
-        // ToDo: Experiment with taking the binary logarithm!
+        // This is faster than taking the base 2 logarithm!
         return Abs(value) switch {
             var identity when identity < Kibi.Factor => injector.Identity(in value),
             var deca when deca < Mebi.Factor => Scale<Kibi>(in injector, in value),

--- a/quantities/prefixes/BinaryPrefix.cs
+++ b/quantities/prefixes/BinaryPrefix.cs
@@ -1,0 +1,30 @@
+using Quantities.Dimensions;
+using Quantities.Units.Si;
+using static System.Math;
+
+namespace Quantities.Prefixes;
+
+internal static class BinaryPrefix
+{
+    public static T Scale<T>(in Double value, IPrefixInject<T> injector)
+    {
+        // ToDo: Experiment with taking the binary logarithm!
+        return Abs(value) switch {
+            var identity when identity < Kibi.Factor => injector.Identity(in value),
+            var deca when deca < Mebi.Factor => Scale<Kibi>(in injector, in value),
+            var hecto when hecto < Gibi.Factor => Scale<Mebi>(in injector, in value),
+            var kilo when kilo < Tebi.Factor => Scale<Gibi>(in injector, in value),
+            var mega when mega < Pebi.Factor => Scale<Tebi>(in injector, in value),
+            var giga when giga < Exbi.Factor => Scale<Pebi>(in injector, in value),
+            var tera when tera < Zebi.Factor => Scale<Exbi>(in injector, in value),
+            var peta when peta < Yobi.Factor => Scale<Zebi>(in injector, in value),
+            _ => Scale<Yobi>(in injector, in value)
+        };
+
+        static T Scale<TPrefix>(in IPrefixInject<T> injector, in Double value)
+            where TPrefix : IBinaryPrefix
+        {
+            return injector.Inject<TPrefix>(TPrefix.FromSi(in value));
+        }
+    }
+}

--- a/quantities/prefixes/BinaryPrefixes.cs
+++ b/quantities/prefixes/BinaryPrefixes.cs
@@ -16,64 +16,64 @@ yobi Yi 1208925819614629174706176 2^80
 [DebuggerDisplay(nameof(Kibi))]
 public readonly struct Kibi : IIecPrefix, IScaleUp
 {
-    private const UInt32 factor = 1024;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = 1024;
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Ki";
 }
 [DebuggerDisplay(nameof(Mebi))]
 public readonly struct Mebi : IIecPrefix, IScaleUp
 {
-    private const UInt32 factor = 1048576;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = 1048576;
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Mi";
 }
 [DebuggerDisplay(nameof(Gibi))]
 public readonly struct Gibi : IIecPrefix, IScaleUp
 {
-    private const UInt32 factor = 1073741824;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = 1073741824;
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Gi";
 }
 [DebuggerDisplay(nameof(Tebi))]
 public readonly struct Tebi : IIecPrefix, IScaleUp
 {
-    private const UInt64 factor = 1099511627776;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = 1099511627776;
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Ti";
 }
 [DebuggerDisplay(nameof(Pebi))]
 public readonly struct Pebi : IIecPrefix, IScaleUp
 {
-    private const UInt64 factor = 1125899906842624;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = 1125899906842624;
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Pi";
 }
 [DebuggerDisplay(nameof(Exbi))]
 public readonly struct Exbi : IIecPrefix, IScaleUp
 {
-    private const UInt64 factor = 1152921504606846976;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = 1152921504606846976;
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Ei";
 }
 [DebuggerDisplay(nameof(Zebi))]
 public readonly struct Zebi : IIecPrefix, IScaleUp
 {
-    private const Double factor = 1024d * 1152921504606846976; // 1180591620717411303424;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = Gibi.Factor * Tebi.Factor; // 1180591620717411303424
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Zi";
 }
 [DebuggerDisplay(nameof(Yobi))]
 public readonly struct Yobi : IIecPrefix, IScaleUp
 {
-    private const Double factor = 1024 * 1024d * 1152921504606846976;
-    static Double ITransform.ToSi(in Double value) => factor * value;
-    static Double ITransform.FromSi(in Double value) => value / factor;
+    internal const Double Factor = Tebi.Factor * Tebi.Factor; // 1208925819614629174706176
+    static Double ITransform.ToSi(in Double value) => Factor * value;
+    static Double ITransform.FromSi(in Double value) => value / Factor;
     public static String Representation => "Yi";
 }

--- a/quantities/prefixes/BinaryPrefixes.cs
+++ b/quantities/prefixes/BinaryPrefixes.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+
+namespace Quantities.Prefixes;
+
+/*
+kibi Ki 1024 2^10
+mebi Mi 1048576 2^20
+gibi Gi 1073741824 2^30
+tebi Ti 1099511627776 2^40
+pebi Pi 1125899906842624 2^50
+exbi Ei 1152921504606846976 2^60
+zebi Zi 1180591620717411303424 2^70
+yobi Yi 1208925819614629174706176 2^80
+*/
+
+[DebuggerDisplay(nameof(Kibi))]
+public readonly struct Kibi : IIecPrefix, IScaleUp
+{
+    private const UInt32 factor = 1024;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Ki";
+}
+[DebuggerDisplay(nameof(Mebi))]
+public readonly struct Mebi : IIecPrefix, IScaleUp
+{
+    private const UInt32 factor = 1048576;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Mi";
+}
+[DebuggerDisplay(nameof(Gibi))]
+public readonly struct Gibi : IIecPrefix, IScaleUp
+{
+    private const UInt32 factor = 1073741824;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Gi";
+}
+[DebuggerDisplay(nameof(Tebi))]
+public readonly struct Tebi : IIecPrefix, IScaleUp
+{
+    private const UInt64 factor = 1099511627776;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Ti";
+}
+[DebuggerDisplay(nameof(Pebi))]
+public readonly struct Pebi : IIecPrefix, IScaleUp
+{
+    private const UInt64 factor = 1125899906842624;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Pi";
+}
+[DebuggerDisplay(nameof(Exbi))]
+public readonly struct Exbi : IIecPrefix, IScaleUp
+{
+    private const UInt64 factor = 1152921504606846976;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Ei";
+}
+[DebuggerDisplay(nameof(Zebi))]
+public readonly struct Zebi : IIecPrefix, IScaleUp
+{
+    private const Double factor = 1024d * 1152921504606846976; // 1180591620717411303424;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Zi";
+}
+[DebuggerDisplay(nameof(Yobi))]
+public readonly struct Yobi : IIecPrefix, IScaleUp
+{
+    private const Double factor = 1024 * 1024d * 1152921504606846976;
+    static Double ITransform.ToSi(in Double value) => factor * value;
+    static Double ITransform.FromSi(in Double value) => value / factor;
+    public static String Representation => "Yi";
+}

--- a/quantities/prefixes/BinaryPrefixes.cs
+++ b/quantities/prefixes/BinaryPrefixes.cs
@@ -14,7 +14,7 @@ yobi Yi 1208925819614629174706176 2^80
 */
 
 [DebuggerDisplay(nameof(Kibi))]
-public readonly struct Kibi : IIecPrefix, IScaleUp
+public readonly struct Kibi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = 1024;
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -22,7 +22,7 @@ public readonly struct Kibi : IIecPrefix, IScaleUp
     public static String Representation => "Ki";
 }
 [DebuggerDisplay(nameof(Mebi))]
-public readonly struct Mebi : IIecPrefix, IScaleUp
+public readonly struct Mebi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = 1048576;
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -30,7 +30,7 @@ public readonly struct Mebi : IIecPrefix, IScaleUp
     public static String Representation => "Mi";
 }
 [DebuggerDisplay(nameof(Gibi))]
-public readonly struct Gibi : IIecPrefix, IScaleUp
+public readonly struct Gibi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = 1073741824;
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -38,7 +38,7 @@ public readonly struct Gibi : IIecPrefix, IScaleUp
     public static String Representation => "Gi";
 }
 [DebuggerDisplay(nameof(Tebi))]
-public readonly struct Tebi : IIecPrefix, IScaleUp
+public readonly struct Tebi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = 1099511627776;
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -46,7 +46,7 @@ public readonly struct Tebi : IIecPrefix, IScaleUp
     public static String Representation => "Ti";
 }
 [DebuggerDisplay(nameof(Pebi))]
-public readonly struct Pebi : IIecPrefix, IScaleUp
+public readonly struct Pebi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = 1125899906842624;
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -54,7 +54,7 @@ public readonly struct Pebi : IIecPrefix, IScaleUp
     public static String Representation => "Pi";
 }
 [DebuggerDisplay(nameof(Exbi))]
-public readonly struct Exbi : IIecPrefix, IScaleUp
+public readonly struct Exbi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = 1152921504606846976;
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -62,7 +62,7 @@ public readonly struct Exbi : IIecPrefix, IScaleUp
     public static String Representation => "Ei";
 }
 [DebuggerDisplay(nameof(Zebi))]
-public readonly struct Zebi : IIecPrefix, IScaleUp
+public readonly struct Zebi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = Gibi.Factor * Tebi.Factor; // 1180591620717411303424
     static Double ITransform.ToSi(in Double value) => Factor * value;
@@ -70,7 +70,7 @@ public readonly struct Zebi : IIecPrefix, IScaleUp
     public static String Representation => "Zi";
 }
 [DebuggerDisplay(nameof(Yobi))]
-public readonly struct Yobi : IIecPrefix, IScaleUp
+public readonly struct Yobi : IBinaryPrefix, IScaleUp
 {
     internal const Double Factor = Tebi.Factor * Tebi.Factor; // 1208925819614629174706176
     static Double ITransform.ToSi(in Double value) => Factor * value;

--- a/quantities/prefixes/IPrefix.cs
+++ b/quantities/prefixes/IPrefix.cs
@@ -1,11 +1,9 @@
 namespace Quantities.Prefixes;
 
-public interface IPrefix : ITransform, IRepresentable
-{
-}
-public interface ISiPrefix : IPrefix
-{
-}
-public interface IIecPrefix : IPrefix
-{
-}
+public interface IPrefix : ITransform, IRepresentable { /* marker interface */ }
+
+// ToDo: Consider renaming to IMetricPrefix
+public interface ISiPrefix : IPrefix { /* marker interface */ }
+
+// ToDo: Consider renaming to IBinaryPrefix
+public interface IIecPrefix : IPrefix { /* marker interface */ }

--- a/quantities/prefixes/IPrefix.cs
+++ b/quantities/prefixes/IPrefix.cs
@@ -1,9 +1,5 @@
 namespace Quantities.Prefixes;
 
 public interface IPrefix : ITransform, IRepresentable { /* marker interface */ }
-
-// ToDo: Consider renaming to IMetricPrefix
-public interface ISiPrefix : IPrefix { /* marker interface */ }
-
-// ToDo: Consider renaming to IBinaryPrefix
-public interface IIecPrefix : IPrefix { /* marker interface */ }
+public interface IMetricPrefix : IPrefix { /* marker interface */ }
+public interface IBinaryPrefix : IPrefix { /* marker interface */ }

--- a/quantities/prefixes/IPrefix.cs
+++ b/quantities/prefixes/IPrefix.cs
@@ -3,3 +3,9 @@ namespace Quantities.Prefixes;
 public interface IPrefix : ITransform, IRepresentable
 {
 }
+public interface ISiPrefix : IPrefix
+{
+}
+public interface IIecPrefix : IPrefix
+{
+}

--- a/quantities/prefixes/MetricPrefix.cs
+++ b/quantities/prefixes/MetricPrefix.cs
@@ -2,7 +2,7 @@ using static System.Math;
 
 namespace Quantities.Prefixes;
 
-internal static class SiPrefix
+internal static class MetricPrefix
 {
     public static T Scale<T>(in Double value, IPrefixInject<T> injector)
     {
@@ -41,7 +41,7 @@ internal static class SiPrefix
         };
 
         static T Scale<TPrefix>(in IPrefixInject<T> injector, in Double value)
-            where TPrefix : ISiPrefix
+            where TPrefix : IMetricPrefix
         {
             return injector.Inject<TPrefix>(TPrefix.FromSi(in value));
         }
@@ -79,7 +79,7 @@ internal static class SiPrefix
         };
 
         static T Scale<TPrefix>(in IPrefixInject<T> injector, in Double value)
-            where TPrefix : ISiPrefix
+            where TPrefix : IMetricPrefix
         {
             return injector.Inject<TPrefix>(TPrefix.FromSi(in value));
         }

--- a/quantities/prefixes/MetricPrefixes.cs
+++ b/quantities/prefixes/MetricPrefixes.cs
@@ -31,168 +31,168 @@ quecto 	q 	0.000000000000000000000000000001   1e-30
 */
 
 [DebuggerDisplay(nameof(Quetta))]
-public readonly struct Quetta : ISiPrefix, IScaleUp
+public readonly struct Quetta : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e30 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e30;
     static String IRepresentable.Representation => "Q";
 }
 [DebuggerDisplay(nameof(Ronna))]
-public readonly struct Ronna : ISiPrefix, IScaleUp
+public readonly struct Ronna : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e27 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e27;
     static String IRepresentable.Representation => "R";
 }
 [DebuggerDisplay(nameof(Yotta))]
-public readonly struct Yotta : ISiPrefix, IScaleUp
+public readonly struct Yotta : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e24 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e24;
     static String IRepresentable.Representation => "Y";
 }
 [DebuggerDisplay(nameof(Zetta))]
-public readonly struct Zetta : ISiPrefix, IScaleUp
+public readonly struct Zetta : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e21 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e21;
     static String IRepresentable.Representation => "Z";
 }
 [DebuggerDisplay(nameof(Exa))]
-public readonly struct Exa : ISiPrefix, IScaleUp
+public readonly struct Exa : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e18 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e18;
     static String IRepresentable.Representation => "E";
 }
 [DebuggerDisplay(nameof(Peta))]
-public readonly struct Peta : ISiPrefix, IScaleUp
+public readonly struct Peta : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e15 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e15;
     static String IRepresentable.Representation => "P";
 }
 [DebuggerDisplay(nameof(Tera))]
-public readonly struct Tera : ISiPrefix, IScaleUp
+public readonly struct Tera : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e12 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e12;
     static String IRepresentable.Representation => "T";
 }
 [DebuggerDisplay(nameof(Giga))]
-public readonly struct Giga : ISiPrefix, IScaleUp
+public readonly struct Giga : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e9 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e9;
     static String IRepresentable.Representation => "G";
 }
 [DebuggerDisplay(nameof(Mega))]
-public readonly struct Mega : ISiPrefix, IScaleUp
+public readonly struct Mega : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e6 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e6;
     static String IRepresentable.Representation => "M";
 }
 [DebuggerDisplay(nameof(Kilo))]
-public readonly struct Kilo : ISiPrefix, IScaleUp
+public readonly struct Kilo : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e3 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e3;
     static String IRepresentable.Representation => "K";
 }
 [DebuggerDisplay(nameof(Hecto))]
-public readonly struct Hecto : ISiPrefix, IScaleUp
+public readonly struct Hecto : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e2 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e2;
     static String IRepresentable.Representation => "h";
 }
 [DebuggerDisplay(nameof(Deca))]
-public readonly struct Deca : ISiPrefix, IScaleUp
+public readonly struct Deca : IMetricPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e1 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e1;
     static String IRepresentable.Representation => "da";
 }
 [DebuggerDisplay(nameof(Deci))]
-public readonly struct Deci : ISiPrefix, IScaleDown
+public readonly struct Deci : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e1;
     static Double ITransform.FromSi(in Double value) => 1e1 * value;
     static String IRepresentable.Representation => "d";
 }
 [DebuggerDisplay(nameof(Centi))]
-public readonly struct Centi : ISiPrefix, IScaleDown
+public readonly struct Centi : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e2;
     static Double ITransform.FromSi(in Double value) => 1e2 * value;
     static String IRepresentable.Representation => "c";
 }
 [DebuggerDisplay(nameof(Milli))]
-public readonly struct Milli : ISiPrefix, IScaleDown
+public readonly struct Milli : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e3;
     static Double ITransform.FromSi(in Double value) => 1e3 * value;
     static String IRepresentable.Representation => "m";
 }
 [DebuggerDisplay(nameof(Micro))]
-public readonly struct Micro : ISiPrefix, IScaleDown
+public readonly struct Micro : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e6;
     static Double ITransform.FromSi(in Double value) => 1e6 * value;
     static String IRepresentable.Representation => "μ";
 }
 [DebuggerDisplay(nameof(Nano))]
-public readonly struct Nano : ISiPrefix, IScaleDown
+public readonly struct Nano : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e9;
     static Double ITransform.FromSi(in Double value) => 1e9 * value;
     static String IRepresentable.Representation => "n";
 }
 [DebuggerDisplay(nameof(Pico))]
-public readonly struct Pico : ISiPrefix, IScaleDown
+public readonly struct Pico : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e12;
     static Double ITransform.FromSi(in Double value) => 1e12 * value;
     static String IRepresentable.Representation => "p";
 }
 [DebuggerDisplay(nameof(Femto))]
-public readonly struct Femto : ISiPrefix, IScaleDown
+public readonly struct Femto : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e15;
     static Double ITransform.FromSi(in Double value) => 1e15 * value;
     static String IRepresentable.Representation => "f";
 }
 [DebuggerDisplay(nameof(Atto))]
-public readonly struct Atto : ISiPrefix, IScaleDown
+public readonly struct Atto : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e18;
     static Double ITransform.FromSi(in Double value) => 1e18 * value;
     static String IRepresentable.Representation => "a";
 }
 [DebuggerDisplay(nameof(Zepto))]
-public readonly struct Zepto : ISiPrefix, IScaleDown
+public readonly struct Zepto : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e21;
     static Double ITransform.FromSi(in Double value) => 1e21 * value;
     static String IRepresentable.Representation => "z";
 }
 [DebuggerDisplay(nameof(Yocto))]
-public readonly struct Yocto : ISiPrefix, IScaleDown
+public readonly struct Yocto : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e24;
     static Double ITransform.FromSi(in Double value) => 1e24 * value;
     static String IRepresentable.Representation => "y";
 }
 [DebuggerDisplay(nameof(Ronto))]
-public readonly struct Ronto : ISiPrefix, IScaleDown
+public readonly struct Ronto : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e27;
     static Double ITransform.FromSi(in Double value) => 1e27 * value;
     static String IRepresentable.Representation => "r";
 }
 [DebuggerDisplay(nameof(Quecto))]
-public readonly struct Quecto : ISiPrefix, IScaleDown
+public readonly struct Quecto : IMetricPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e30;
     static Double ITransform.FromSi(in Double value) => 1e30 * value;

--- a/quantities/prefixes/SiPrefix.cs
+++ b/quantities/prefixes/SiPrefix.cs
@@ -41,7 +41,7 @@ internal static class SiPrefix
         };
 
         static T Scale<TPrefix>(in IPrefixInject<T> injector, in Double value)
-            where TPrefix : IPrefix
+            where TPrefix : ISiPrefix
         {
             return injector.Inject<TPrefix>(TPrefix.FromSi(in value));
         }
@@ -79,7 +79,7 @@ internal static class SiPrefix
         };
 
         static T Scale<TPrefix>(in IPrefixInject<T> injector, in Double value)
-            where TPrefix : IPrefix
+            where TPrefix : ISiPrefix
         {
             return injector.Inject<TPrefix>(TPrefix.FromSi(in value));
         }

--- a/quantities/prefixes/SiPrefixes.cs
+++ b/quantities/prefixes/SiPrefixes.cs
@@ -31,175 +31,175 @@ quecto 	q 	0.000000000000000000000000000001   1e-30
 */
 
 [DebuggerDisplay(nameof(Quetta))]
-public readonly struct Quetta : IPrefix, IScaleUp
+public readonly struct Quetta : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e30 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e30;
     static String IRepresentable.Representation => "Q";
 }
 [DebuggerDisplay(nameof(Ronna))]
-public readonly struct Ronna : IPrefix, IScaleUp
+public readonly struct Ronna : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e27 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e27;
     static String IRepresentable.Representation => "R";
 }
 [DebuggerDisplay(nameof(Yotta))]
-public readonly struct Yotta : IPrefix, IScaleUp
+public readonly struct Yotta : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e24 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e24;
     static String IRepresentable.Representation => "Y";
 }
 [DebuggerDisplay(nameof(Zetta))]
-public readonly struct Zetta : IPrefix, IScaleUp
+public readonly struct Zetta : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e21 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e21;
     static String IRepresentable.Representation => "Z";
 }
 [DebuggerDisplay(nameof(Exa))]
-public readonly struct Exa : IPrefix, IScaleUp
+public readonly struct Exa : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e18 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e18;
     static String IRepresentable.Representation => "E";
 }
 [DebuggerDisplay(nameof(Peta))]
-public readonly struct Peta : IPrefix, IScaleUp
+public readonly struct Peta : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e15 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e15;
     static String IRepresentable.Representation => "P";
 }
 [DebuggerDisplay(nameof(Tera))]
-public readonly struct Tera : IPrefix, IScaleUp
+public readonly struct Tera : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e12 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e12;
     static String IRepresentable.Representation => "T";
 }
 [DebuggerDisplay(nameof(Giga))]
-public readonly struct Giga : IPrefix, IScaleUp
+public readonly struct Giga : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e9 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e9;
     static String IRepresentable.Representation => "G";
 }
 [DebuggerDisplay(nameof(Mega))]
-public readonly struct Mega : IPrefix, IScaleUp
+public readonly struct Mega : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e6 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e6;
     static String IRepresentable.Representation => "M";
 }
 [DebuggerDisplay(nameof(Kilo))]
-public readonly struct Kilo : IPrefix, IScaleUp
+public readonly struct Kilo : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e3 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e3;
     static String IRepresentable.Representation => "K";
 }
 [DebuggerDisplay(nameof(Hecto))]
-public readonly struct Hecto : IPrefix, IScaleUp
+public readonly struct Hecto : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e2 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e2;
     static String IRepresentable.Representation => "h";
 }
 [DebuggerDisplay(nameof(Deca))]
-public readonly struct Deca : IPrefix, IScaleUp
+public readonly struct Deca : ISiPrefix, IScaleUp
 {
     static Double ITransform.ToSi(in Double value) => 1e1 * value;
     static Double ITransform.FromSi(in Double value) => value / 1e1;
     static String IRepresentable.Representation => "da";
 }
 [DebuggerDisplay("1")]
-internal readonly struct UnitPrefix : IPrefix, IScaleUp, IScaleDown // Since we use it by default on unit-less instantiations.
+internal readonly struct UnitPrefix : ISiPrefix, IScaleUp, IScaleDown // Since we use it by default on unit-less instantiations.
 {
     static Double ITransform.ToSi(in Double value) => value;
     static Double ITransform.FromSi(in Double value) => value;
     static String IRepresentable.Representation => String.Empty;
 }
 [DebuggerDisplay(nameof(Deci))]
-public readonly struct Deci : IPrefix, IScaleDown
+public readonly struct Deci : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e1;
     static Double ITransform.FromSi(in Double value) => 1e1 * value;
     static String IRepresentable.Representation => "d";
 }
 [DebuggerDisplay(nameof(Centi))]
-public readonly struct Centi : IPrefix, IScaleDown
+public readonly struct Centi : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e2;
     static Double ITransform.FromSi(in Double value) => 1e2 * value;
     static String IRepresentable.Representation => "c";
 }
 [DebuggerDisplay(nameof(Milli))]
-public readonly struct Milli : IPrefix, IScaleDown
+public readonly struct Milli : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e3;
     static Double ITransform.FromSi(in Double value) => 1e3 * value;
     static String IRepresentable.Representation => "m";
 }
 [DebuggerDisplay(nameof(Micro))]
-public readonly struct Micro : IPrefix, IScaleDown
+public readonly struct Micro : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e6;
     static Double ITransform.FromSi(in Double value) => 1e6 * value;
     static String IRepresentable.Representation => "μ";
 }
 [DebuggerDisplay(nameof(Nano))]
-public readonly struct Nano : IPrefix, IScaleDown
+public readonly struct Nano : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e9;
     static Double ITransform.FromSi(in Double value) => 1e9 * value;
     static String IRepresentable.Representation => "n";
 }
 [DebuggerDisplay(nameof(Pico))]
-public readonly struct Pico : IPrefix, IScaleDown
+public readonly struct Pico : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e12;
     static Double ITransform.FromSi(in Double value) => 1e12 * value;
     static String IRepresentable.Representation => "p";
 }
 [DebuggerDisplay(nameof(Femto))]
-public readonly struct Femto : IPrefix, IScaleDown
+public readonly struct Femto : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e15;
     static Double ITransform.FromSi(in Double value) => 1e15 * value;
     static String IRepresentable.Representation => "f";
 }
 [DebuggerDisplay(nameof(Atto))]
-public readonly struct Atto : IPrefix, IScaleDown
+public readonly struct Atto : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e18;
     static Double ITransform.FromSi(in Double value) => 1e18 * value;
     static String IRepresentable.Representation => "a";
 }
 [DebuggerDisplay(nameof(Zepto))]
-public readonly struct Zepto : IPrefix, IScaleDown
+public readonly struct Zepto : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e21;
     static Double ITransform.FromSi(in Double value) => 1e21 * value;
     static String IRepresentable.Representation => "z";
 }
 [DebuggerDisplay(nameof(Yocto))]
-public readonly struct Yocto : IPrefix, IScaleDown
+public readonly struct Yocto : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e24;
     static Double ITransform.FromSi(in Double value) => 1e24 * value;
     static String IRepresentable.Representation => "y";
 }
 [DebuggerDisplay(nameof(Ronto))]
-public readonly struct Ronto : IPrefix, IScaleDown
+public readonly struct Ronto : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e27;
     static Double ITransform.FromSi(in Double value) => 1e27 * value;
     static String IRepresentable.Representation => "r";
 }
 [DebuggerDisplay(nameof(Quecto))]
-public readonly struct Quecto : IPrefix, IScaleDown
+public readonly struct Quecto : ISiPrefix, IScaleDown
 {
     static Double ITransform.ToSi(in Double value) => value / 1e30;
     static Double ITransform.FromSi(in Double value) => 1e30 * value;

--- a/quantities/prefixes/SiPrefixes.cs
+++ b/quantities/prefixes/SiPrefixes.cs
@@ -114,13 +114,6 @@ public readonly struct Deca : ISiPrefix, IScaleUp
     static Double ITransform.FromSi(in Double value) => value / 1e1;
     static String IRepresentable.Representation => "da";
 }
-[DebuggerDisplay("1")]
-internal readonly struct UnitPrefix : ISiPrefix, IScaleUp, IScaleDown // Since we use it by default on unit-less instantiations.
-{
-    static Double ITransform.ToSi(in Double value) => value;
-    static Double ITransform.FromSi(in Double value) => value;
-    static String IRepresentable.Representation => String.Empty;
-}
 [DebuggerDisplay(nameof(Deci))]
 public readonly struct Deci : ISiPrefix, IScaleDown
 {

--- a/quantities/quantities/Area.cs
+++ b/quantities/quantities/Area.cs
@@ -25,7 +25,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(this.quant.To<Square, Si<TUnit>>());
     }
     public Area ToSquare<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(this.quant.To<Square, Si<TPrefix, TUnit>>());
@@ -36,7 +36,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(this.quant.As<Metric<TArea>, Alias<TArea, ILength>>());
     }
     public Area ToMetric<TPrefix, TArea>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TArea : IMetricUnit, IArea<ILength>, IInjectUnit<ILength>
     {
         return new(this.quant.As<Metric<TPrefix, TArea>, Alias<TPrefix, TArea, ILength>>());
@@ -62,7 +62,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(value.To<Square, Si<TUnit>>());
     }
     public static Area Square<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(value.To<Square, Si<TPrefix, TUnit>>());
@@ -73,7 +73,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(value.As<Metric<TArea>, Alias<TArea, ILength>>());
     }
     public static Area Metric<TPrefix, TArea>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TArea : IMetricUnit, IArea<ILength>, IInjectUnit<ILength>
     {
         return new(value.As<Metric<TPrefix, TArea>, Alias<TPrefix, TArea, ILength>>());

--- a/quantities/quantities/Area.cs
+++ b/quantities/quantities/Area.cs
@@ -25,7 +25,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(this.quant.To<Square, Si<TUnit>>());
     }
     public Area ToSquare<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(this.quant.To<Square, Si<TPrefix, TUnit>>());
@@ -36,7 +36,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(this.quant.As<Metric<TArea>, Alias<TArea, ILength>>());
     }
     public Area ToMetric<TPrefix, TArea>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TArea : IMetricUnit, IArea<ILength>, IInjectUnit<ILength>
     {
         return new(this.quant.As<Metric<TPrefix, TArea>, Alias<TPrefix, TArea, ILength>>());
@@ -62,7 +62,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(value.To<Square, Si<TUnit>>());
     }
     public static Area Square<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(value.To<Square, Si<TPrefix, TUnit>>());
@@ -73,7 +73,7 @@ public readonly struct Area : IQuantity<Area>, IArea<Length>
         return new(value.As<Metric<TArea>, Alias<TArea, ILength>>());
     }
     public static Area Metric<TPrefix, TArea>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TArea : IMetricUnit, IArea<ILength>, IInjectUnit<ILength>
     {
         return new(value.As<Metric<TPrefix, TArea>, Alias<TPrefix, TArea, ILength>>());

--- a/quantities/quantities/Data.cs
+++ b/quantities/quantities/Data.cs
@@ -1,0 +1,60 @@
+using Quantities.Dimensions;
+using Quantities.Measures;
+using Quantities.Prefixes;
+using Quantities.Units.Si;
+
+namespace Quantities.Quantities;
+
+/* This one is complicated..
+- https://en.wikipedia.org/wiki/Units_of_information
+- https://en.wikipedia.org/wiki/Bit
+- https://en.wikipedia.org/wiki/Byte#History
+*/
+/* ToDo: Find better naming:
+- AmountOfInformation
+- DataSize
+- AmountOfData
+- Information
+*/
+public readonly struct Data : IQuantity<Data>, IAmountOfInformation
+{
+    private readonly Quant quant;
+    internal Quant Quant => this.quant;
+    private Data(in Quant quant) => this.quant = quant;
+    public Data ToMetric<TUnit>() where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new(this.quant.As<Metric<TUnit>>());
+    }
+    public Data ToMetric<TPrefix, TUnit>()
+        where TPrefix : IPrefix, IScaleUp// Metric & Binary Prefixes are ok!
+        where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new(this.quant.As<Metric<TPrefix, TUnit>>());
+    }
+    public static Data Metric<TUnit>(in Double value) where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new(value.As<Metric<TUnit>>());
+    }
+    public static Data Metric<TPrefix, TUnit>(in Double value)
+        where TPrefix : IPrefix, IScaleUp // Metric & Binary Prefixes are ok!
+        where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new(value.As<Metric<TPrefix, TUnit>>());
+    }
+
+    public Boolean Equals(Data other) => this.quant.Equals(other.quant);
+    public override Boolean Equals(Object? obj) => obj is Data data && Equals(data);
+    public override Int32 GetHashCode() => this.quant.GetHashCode();
+    public override String ToString() => this.quant.ToString();
+    public String ToString(String? format, IFormatProvider? provider) => this.quant.ToString(format, provider);
+
+    public static Boolean operator ==(Data left, Data right) => left.Equals(right);
+    public static Boolean operator !=(Data left, Data right) => !left.Equals(right);
+    public static implicit operator Double(Data data) => data.quant.Value;
+    public static Data operator +(Data left, Data right) => new(left.quant + right.quant);
+    public static Data operator -(Data left, Data right) => new(left.quant - right.quant);
+    public static Data operator *(Double scalar, Data right) => new(scalar * right.quant);
+    public static Data operator *(Data left, Double scalar) => new(scalar * left.quant);
+    public static Data operator /(Data left, Double scalar) => new(left.quant / scalar);
+    public static Double operator /(Data left, Data right) => left.quant / right.quant;
+}

--- a/quantities/quantities/Data.cs
+++ b/quantities/quantities/Data.cs
@@ -24,21 +24,21 @@ public readonly struct Data : IQuantity<Data>, IAmountOfInformation
     private readonly Quant quant;
     internal Quant Quant => this.quant;
     private Data(in Quant quant) => this.quant = quant;
-    public Data ToMetric<TUnit>() where TUnit : IMetricUnit, IAmountOfInformation
+    public Data To<TUnit>() where TUnit : IMetricUnit, IAmountOfInformation
     {
         return new(this.quant.As<Metric<TUnit>>());
     }
-    public Data ToMetric<TPrefix, TUnit>()
+    public Data To<TPrefix, TUnit>()
         where TPrefix : IPrefix, IScaleUp// Metric & Binary Prefixes are ok!
         where TUnit : IMetricUnit, IAmountOfInformation
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
     }
-    public static Data Metric<TUnit>(in Double value) where TUnit : IMetricUnit, IAmountOfInformation
+    public static Data In<TUnit>(in Double value) where TUnit : IMetricUnit, IAmountOfInformation
     {
         return new(value.As<Metric<TUnit>>());
     }
-    public static Data Metric<TPrefix, TUnit>(in Double value)
+    public static Data In<TPrefix, TUnit>(in Double value)
         where TPrefix : IPrefix, IScaleUp // Metric & Binary Prefixes are ok!
         where TUnit : IMetricUnit, IAmountOfInformation
     {

--- a/quantities/quantities/DataRate.cs
+++ b/quantities/quantities/DataRate.cs
@@ -1,0 +1,50 @@
+using Quantities.Dimensions;
+using Quantities.Measures;
+using Quantities.Prefixes;
+using Quantities.Quantities.Builders;
+using Quantities.Units.Si;
+
+namespace Quantities.Quantities;
+
+public readonly struct DataRate : IQuantity<DataRate>, IInformationRate
+{
+    private readonly Quant quant;
+    internal Quant Quant => this.quant;
+    internal DataRate(in Quant quant) => this.quant = quant;
+    public IBuilder<DataRate> ToMetric<TUnit>() where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new Transform<DataRate, Metric<TUnit>>(in this.quant);
+    }
+    public IBuilder<DataRate> ToMetric<TPrefix, TUnit>()
+        where TPrefix : IPrefix, IScaleUp// Metric & Binary Prefixes are ok!
+        where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new Transform<DataRate, Metric<TPrefix, TUnit>>(in this.quant);
+    }
+    public static IBuilder<DataRate> Metric<TUnit>(in Double value) where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new Builder<DataRate, Metric<TUnit>>(in value);
+    }
+    public static IBuilder<DataRate> Metric<TPrefix, TUnit>(in Double value)
+        where TPrefix : IPrefix, IScaleUp // Metric & Binary Prefixes are ok!
+        where TUnit : IMetricUnit, IAmountOfInformation
+    {
+        return new Builder<DataRate, Metric<TPrefix, TUnit>>(in value);
+    }
+
+    public Boolean Equals(DataRate other) => this.quant.Equals(other.quant);
+    public override Boolean Equals(Object? obj) => obj is DataRate rate && Equals(rate);
+    public override Int32 GetHashCode() => this.quant.GetHashCode();
+    public override String ToString() => this.quant.ToString();
+    public String ToString(String? format, IFormatProvider? provider) => this.quant.ToString(format, provider);
+
+    public static Boolean operator ==(DataRate left, DataRate right) => left.Equals(right);
+    public static Boolean operator !=(DataRate left, DataRate right) => !left.Equals(right);
+    public static implicit operator Double(DataRate rate) => rate.quant.Value;
+    public static DataRate operator +(DataRate left, DataRate right) => new(left.quant + right.quant);
+    public static DataRate operator -(DataRate left, DataRate right) => new(left.quant - right.quant);
+    public static DataRate operator *(Double scalar, DataRate right) => new(scalar * right.quant);
+    public static DataRate operator *(DataRate left, Double scalar) => new(scalar * left.quant);
+    public static DataRate operator /(DataRate left, Double scalar) => new(left.quant / scalar);
+    public static Double operator /(DataRate left, DataRate right) => left.quant / right.quant;
+}

--- a/quantities/quantities/DataRate.cs
+++ b/quantities/quantities/DataRate.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Quantities.Dimensions;
 using Quantities.Measures;
 using Quantities.Prefixes;
@@ -7,6 +8,7 @@ using Quantities.Units.Si;
 namespace Quantities.Quantities;
 
 public readonly struct DataRate : IQuantity<DataRate>, IInformationRate
+    , IMultiplyOperators<DataRate, Time, Data>
 {
     private readonly Quant quant;
     internal Quant Quant => this.quant;
@@ -32,6 +34,8 @@ public readonly struct DataRate : IQuantity<DataRate>, IInformationRate
         return new Builder<DataRate, Metric<TPrefix, TUnit>>(in value);
     }
 
+    internal static DataRate From(in Data data, in Time time) => new(data.Quant.Divide(time.Quant));
+
     public Boolean Equals(DataRate other) => this.quant.Equals(other.quant);
     public override Boolean Equals(Object? obj) => obj is DataRate rate && Equals(rate);
     public override Int32 GetHashCode() => this.quant.GetHashCode();
@@ -47,4 +51,6 @@ public readonly struct DataRate : IQuantity<DataRate>, IInformationRate
     public static DataRate operator *(DataRate left, Double scalar) => new(scalar * left.quant);
     public static DataRate operator /(DataRate left, Double scalar) => new(left.quant / scalar);
     public static Double operator /(DataRate left, DataRate right) => left.quant / right.quant;
+
+    public static Data operator *(DataRate left, Time right) => Data.From(in right, in left);
 }

--- a/quantities/quantities/DataRate.cs
+++ b/quantities/quantities/DataRate.cs
@@ -13,21 +13,21 @@ public readonly struct DataRate : IQuantity<DataRate>, IInformationRate
     private readonly Quant quant;
     internal Quant Quant => this.quant;
     internal DataRate(in Quant quant) => this.quant = quant;
-    public IBuilder<DataRate> ToMetric<TUnit>() where TUnit : IMetricUnit, IAmountOfInformation
+    public IBuilder<DataRate> To<TUnit>() where TUnit : IMetricUnit, IAmountOfInformation
     {
         return new Transform<DataRate, Metric<TUnit>>(in this.quant);
     }
-    public IBuilder<DataRate> ToMetric<TPrefix, TUnit>()
+    public IBuilder<DataRate> To<TPrefix, TUnit>()
         where TPrefix : IPrefix, IScaleUp// Metric & Binary Prefixes are ok!
         where TUnit : IMetricUnit, IAmountOfInformation
     {
         return new Transform<DataRate, Metric<TPrefix, TUnit>>(in this.quant);
     }
-    public static IBuilder<DataRate> Metric<TUnit>(in Double value) where TUnit : IMetricUnit, IAmountOfInformation
+    public static IBuilder<DataRate> In<TUnit>(in Double value) where TUnit : IMetricUnit, IAmountOfInformation
     {
         return new Builder<DataRate, Metric<TUnit>>(in value);
     }
-    public static IBuilder<DataRate> Metric<TPrefix, TUnit>(in Double value)
+    public static IBuilder<DataRate> In<TPrefix, TUnit>(in Double value)
         where TPrefix : IPrefix, IScaleUp // Metric & Binary Prefixes are ok!
         where TUnit : IMetricUnit, IAmountOfInformation
     {

--- a/quantities/quantities/ElectricCurrent.cs
+++ b/quantities/quantities/ElectricCurrent.cs
@@ -21,7 +21,7 @@ public readonly struct ElectricCurrent : IQuantity<ElectricCurrent>, IElectricCu
         return new(this.quant.As<Si<TUnit>>());
     }
     public ElectricCurrent To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, IElectricCurrent
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -32,7 +32,7 @@ public readonly struct ElectricCurrent : IQuantity<ElectricCurrent>, IElectricCu
         return new(value.As<Si<TUnit>>());
     }
     public static ElectricCurrent Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, IElectricCurrent
     {
         return new(value.As<Si<TPrefix, TUnit>>());
@@ -45,11 +45,11 @@ public readonly struct ElectricCurrent : IQuantity<ElectricCurrent>, IElectricCu
     public override String ToString() => this.quant.ToString();
     internal static ElectricCurrent From(in ElectricPotential potential, in ElectricalResistance resistance)
     {
-        return new(SiPrefix.ScaleThree(potential.Quant.SiDivide(resistance.Quant), create));
+        return new(MetricPrefix.ScaleThree(potential.Quant.SiDivide(resistance.Quant), create));
     }
     internal static ElectricCurrent From(in Power power, in ElectricPotential potential)
     {
-        return new(SiPrefix.ScaleThree(power.Quant.SiDivide(potential.Quant), create));
+        return new(MetricPrefix.ScaleThree(power.Quant.SiDivide(potential.Quant), create));
     }
     public static Boolean operator ==(ElectricCurrent left, ElectricCurrent right) => left.Equals(right);
     public static Boolean operator !=(ElectricCurrent left, ElectricCurrent right) => !left.Equals(right);

--- a/quantities/quantities/ElectricCurrent.cs
+++ b/quantities/quantities/ElectricCurrent.cs
@@ -21,7 +21,7 @@ public readonly struct ElectricCurrent : IQuantity<ElectricCurrent>, IElectricCu
         return new(this.quant.As<Si<TUnit>>());
     }
     public ElectricCurrent To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, IElectricCurrent
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -32,7 +32,7 @@ public readonly struct ElectricCurrent : IQuantity<ElectricCurrent>, IElectricCu
         return new(value.As<Si<TUnit>>());
     }
     public static ElectricCurrent Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, IElectricCurrent
     {
         return new(value.As<Si<TPrefix, TUnit>>());

--- a/quantities/quantities/ElectricPotential.cs
+++ b/quantities/quantities/ElectricPotential.cs
@@ -23,7 +23,7 @@ public readonly struct ElectricPotential : IQuantity<ElectricPotential>, IElectr
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public ElectricPotential To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IElectricPotential
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -34,7 +34,7 @@ public readonly struct ElectricPotential : IQuantity<ElectricPotential>, IElectr
         return new(value.As<SiDerived<TUnit>>());
     }
     public static ElectricPotential Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IElectricPotential
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -47,13 +47,13 @@ public readonly struct ElectricPotential : IQuantity<ElectricPotential>, IElectr
     public override String ToString() => this.quant.ToString();
     internal static ElectricPotential From(in ElectricCurrent current, in ElectricalResistance resistance)
     {
-        return new(SiPrefix.ScaleThree(current.Quant.SiMultiply(resistance.Quant), create));
+        return new(MetricPrefix.ScaleThree(current.Quant.SiMultiply(resistance.Quant), create));
     }
     internal static ElectricPotential From(in Power power, in ElectricCurrent current)
     {
         Double siPower = power.To<Watt>();
         Double siCurrent = current.To<Ampere>();
-        return new(SiPrefix.ScaleThree(siPower / siCurrent, create));
+        return new(MetricPrefix.ScaleThree(siPower / siCurrent, create));
     }
 
     public static Boolean operator ==(ElectricPotential left, ElectricPotential right) => left.Equals(right);

--- a/quantities/quantities/ElectricPotential.cs
+++ b/quantities/quantities/ElectricPotential.cs
@@ -23,7 +23,7 @@ public readonly struct ElectricPotential : IQuantity<ElectricPotential>, IElectr
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public ElectricPotential To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IElectricPotential
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -34,7 +34,7 @@ public readonly struct ElectricPotential : IQuantity<ElectricPotential>, IElectr
         return new(value.As<SiDerived<TUnit>>());
     }
     public static ElectricPotential Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IElectricPotential
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());

--- a/quantities/quantities/ElectricalResistance.cs
+++ b/quantities/quantities/ElectricalResistance.cs
@@ -21,7 +21,7 @@ public readonly struct ElectricalResistance : IQuantity<ElectricalResistance>, I
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public ElectricalResistance To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IElectricalResistance
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -32,7 +32,7 @@ public readonly struct ElectricalResistance : IQuantity<ElectricalResistance>, I
         return new(value.As<SiDerived<TUnit>>());
     }
     public static ElectricalResistance Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IElectricalResistance
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -45,7 +45,7 @@ public readonly struct ElectricalResistance : IQuantity<ElectricalResistance>, I
     public String ToString(String? format, IFormatProvider? provider) => this.quant.ToString(format, provider);
     internal static ElectricalResistance From(in ElectricPotential potential, in ElectricCurrent current)
     {
-        return new(SiPrefix.ScaleThree(potential.Quant.SiDivide(current.Quant), create));
+        return new(MetricPrefix.ScaleThree(potential.Quant.SiDivide(current.Quant), create));
     }
     public static Boolean operator ==(ElectricalResistance left, ElectricalResistance right) => left.Equals(right);
     public static Boolean operator !=(ElectricalResistance left, ElectricalResistance right) => !left.Equals(right);

--- a/quantities/quantities/ElectricalResistance.cs
+++ b/quantities/quantities/ElectricalResistance.cs
@@ -21,7 +21,7 @@ public readonly struct ElectricalResistance : IQuantity<ElectricalResistance>, I
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public ElectricalResistance To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IElectricalResistance
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -32,7 +32,7 @@ public readonly struct ElectricalResistance : IQuantity<ElectricalResistance>, I
         return new(value.As<SiDerived<TUnit>>());
     }
     public static ElectricalResistance Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IElectricalResistance
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());

--- a/quantities/quantities/Energy.cs
+++ b/quantities/quantities/Energy.cs
@@ -22,13 +22,13 @@ public readonly struct Energy : IQuantity<Energy>, IEnergy<Mass, Length, Time>
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Energy To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IEnergy
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
     }
     public Energy ToMetric<TPrefix, TPowerUnit, TTimeUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TPowerUnit : ISiDerivedUnit, IPower
         where TTimeUnit : IMetricUnit, ITransform, ITime
     {
@@ -45,13 +45,13 @@ public readonly struct Energy : IQuantity<Energy>, IEnergy<Mass, Length, Time>
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Energy Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IEnergy
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
     }
     public static Energy Si<TPrefix, TPowerUnit, TTimeUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TPowerUnit : ISiDerivedUnit, IPower
         where TTimeUnit : ISiBaseUnit, ITime
     {
@@ -66,7 +66,7 @@ public readonly struct Energy : IQuantity<Energy>, IEnergy<Mass, Length, Time>
         return new(value.AsProduct<SiDerived<TPowerPrefix, TPowerUnit>, Si<TTimePrefix, TTimeUnit>>());
     }
     public static Energy Metric<TPrefix, TPowerUnit, TTimeUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TPowerUnit : ISiDerivedUnit, IPower
         where TTimeUnit : IMetricUnit, ITransform, ITime
     {

--- a/quantities/quantities/Energy.cs
+++ b/quantities/quantities/Energy.cs
@@ -22,13 +22,13 @@ public readonly struct Energy : IQuantity<Energy>, IEnergy<Mass, Length, Time>
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Energy To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IEnergy
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
     }
     public Energy ToMetric<TPrefix, TPowerUnit, TTimeUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TPowerUnit : ISiDerivedUnit, IPower
         where TTimeUnit : IMetricUnit, ITransform, ITime
     {
@@ -45,13 +45,13 @@ public readonly struct Energy : IQuantity<Energy>, IEnergy<Mass, Length, Time>
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Energy Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IEnergy
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
     }
     public static Energy Si<TPrefix, TPowerUnit, TTimeUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TPowerUnit : ISiDerivedUnit, IPower
         where TTimeUnit : ISiBaseUnit, ITime
     {
@@ -66,7 +66,7 @@ public readonly struct Energy : IQuantity<Energy>, IEnergy<Mass, Length, Time>
         return new(value.AsProduct<SiDerived<TPowerPrefix, TPowerUnit>, Si<TTimePrefix, TTimeUnit>>());
     }
     public static Energy Metric<TPrefix, TPowerUnit, TTimeUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TPowerUnit : ISiDerivedUnit, IPower
         where TTimeUnit : IMetricUnit, ITransform, ITime
     {

--- a/quantities/quantities/Force.cs
+++ b/quantities/quantities/Force.cs
@@ -26,7 +26,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Force To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IForce
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -36,7 +36,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
         return new(this.quant.As<Metric<TUnit>>());
     }
     public Force ToMetric<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IForce
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
@@ -57,7 +57,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Force Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IForce
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -68,7 +68,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
     }
 
     public static Force Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IForce
     {
         return new(value.As<Metric<TPrefix, TUnit>>());

--- a/quantities/quantities/Force.cs
+++ b/quantities/quantities/Force.cs
@@ -26,7 +26,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Force To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IForce
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -36,7 +36,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
         return new(this.quant.As<Metric<TUnit>>());
     }
     public Force ToMetric<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IForce
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
@@ -57,7 +57,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Force Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IForce
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -68,7 +68,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
     }
 
     public static Force Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IForce
     {
         return new(value.As<Metric<TPrefix, TUnit>>());
@@ -86,7 +86,7 @@ public readonly struct Force : IQuantity<Force>, IForce<Mass, Length, Time>
 
     internal static Force From(in Power power, in Velocity velocity)
     {
-        return new(SiPrefix.ScaleThree(power.Quant.SiDivide(velocity.Quant), create));
+        return new(MetricPrefix.ScaleThree(power.Quant.SiDivide(velocity.Quant), create));
     }
 
     public Boolean Equals(Force other) => this.quant.Equals(other.quant);

--- a/quantities/quantities/Length.cs
+++ b/quantities/quantities/Length.cs
@@ -15,6 +15,7 @@ public readonly struct Length : IQuantity<Length>, ILength
     , IMultiplyOperators<Length, Area, Volume>
     , IDivisionOperators<Length, Time, Velocity>
 {
+    private static readonly Creator create = new();
     private static readonly ICreate<Quant> linear = new ToLinear();
     private readonly Quant quant;
     internal Quant Quant => this.quant;
@@ -56,6 +57,11 @@ public readonly struct Length : IQuantity<Length>, ILength
         var pseudoArea = area.Quant.Transform(in linear);
         return new(pseudoArea.PseudoDivide(length.Quant));
     }
+    internal static Length From(in Velocity velocity, in Time time)
+    {
+        // ToDo: Recover length units form velocity
+        return new(MetricPrefix.Scale(velocity.Quant.SiMultiply(time.Quant), create));
+    }
     internal static Length From(in Volume volume, in Area area)
     {
         var pseudoArea = area.Quant.Transform(in linear);
@@ -81,4 +87,10 @@ public readonly struct Length : IQuantity<Length>, ILength
     public static Length operator /(Length left, Double scalar) => new(left.quant / scalar);
     public static Double operator /(Length left, Length right) => left.quant / right.quant;
     public static Velocity operator /(Length left, Time right) => Velocity.From(in left, in right);
+
+    private sealed class Creator : IPrefixInject<Quant>
+    {
+        public Quant Identity(in Double value) => value.As<Si<Metre>>();
+        public Quant Inject<TPrefix>(in Double value) where TPrefix : IPrefix => value.As<Si<TPrefix, Metre>>();
+    }
 }

--- a/quantities/quantities/Length.cs
+++ b/quantities/quantities/Length.cs
@@ -25,7 +25,7 @@ public readonly struct Length : IQuantity<Length>, ILength
         return new(this.quant.As<Si<TUnit>>());
     }
     public Length To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -41,7 +41,7 @@ public readonly struct Length : IQuantity<Length>, ILength
         return new(value.As<Si<TUnit>>());
     }
     public static Length Si<TPrefix, TUnit>(in Double value)
-    where TPrefix : ISiPrefix
+    where TPrefix : IMetricPrefix
     where TUnit : ISiBaseUnit, ILength
     {
         return new(value.As<Si<TPrefix, TUnit>>());

--- a/quantities/quantities/Length.cs
+++ b/quantities/quantities/Length.cs
@@ -25,7 +25,7 @@ public readonly struct Length : IQuantity<Length>, ILength
         return new(this.quant.As<Si<TUnit>>());
     }
     public Length To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -41,7 +41,7 @@ public readonly struct Length : IQuantity<Length>, ILength
         return new(value.As<Si<TUnit>>());
     }
     public static Length Si<TPrefix, TUnit>(in Double value)
-    where TPrefix : IPrefix
+    where TPrefix : ISiPrefix
     where TUnit : ISiBaseUnit, ILength
     {
         return new(value.As<Si<TPrefix, TUnit>>());

--- a/quantities/quantities/Mass.cs
+++ b/quantities/quantities/Mass.cs
@@ -20,7 +20,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Mass To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IMass
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -30,7 +30,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(this.quant.As<Metric<TUnit>>());
     }
     public Mass ToMetric<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IMass
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
@@ -47,7 +47,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Mass Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IMass
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -57,7 +57,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(value.As<Metric<TUnit>>());
     }
     public static Mass Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IMass
     {
         return new(value.As<Metric<TPrefix, TUnit>>());

--- a/quantities/quantities/Mass.cs
+++ b/quantities/quantities/Mass.cs
@@ -20,7 +20,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Mass To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IMass
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -30,7 +30,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(this.quant.As<Metric<TUnit>>());
     }
     public Mass ToMetric<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IMass
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
@@ -47,7 +47,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Mass Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IMass
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -57,7 +57,7 @@ public readonly struct Mass : IQuantity<Mass>, IMass
         return new(value.As<Metric<TUnit>>());
     }
     public static Mass Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IMass
     {
         return new(value.As<Metric<TPrefix, TUnit>>());

--- a/quantities/quantities/Power.cs
+++ b/quantities/quantities/Power.cs
@@ -28,7 +28,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Power To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IPower
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -39,7 +39,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(this.quant.As<Metric<TUnit>>());
     }
     public Power ToMetric<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IPower
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
@@ -55,7 +55,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Power Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiDerivedUnit, IPower
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -71,7 +71,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(value.As<Metric<TUnit>>());
     }
     public static Power Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IPower
     {
         return new(value.As<Metric<TPrefix, TUnit>>());
@@ -79,15 +79,15 @@ public readonly struct Power : IQuantity<Power>, IPower
 
     internal static Power From(in ElectricPotential potential, in ElectricCurrent current)
     {
-        return new(SiPrefix.ScaleThree(potential.Quant.SiMultiply(current.Quant), create));
+        return new(MetricPrefix.ScaleThree(potential.Quant.SiMultiply(current.Quant), create));
     }
     internal static Power From(in Force force, in Velocity velocity)
     {
-        return new(SiPrefix.ScaleThree(force.Quant.SiMultiply(velocity.Quant), create));
+        return new(MetricPrefix.ScaleThree(force.Quant.SiMultiply(velocity.Quant), create));
     }
     internal static Power From(in Energy energy, in Time time)
     {
-        return new(SiPrefix.ScaleThree(energy.Quant.SiDivide(time.Quant), create));
+        return new(MetricPrefix.ScaleThree(energy.Quant.SiDivide(time.Quant), create));
     }
 
     public Boolean Equals(Power other) => this.quant.Equals(other.quant);

--- a/quantities/quantities/Power.cs
+++ b/quantities/quantities/Power.cs
@@ -28,7 +28,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(this.quant.As<SiDerived<TUnit>>());
     }
     public Power To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IPower
     {
         return new(this.quant.As<SiDerived<TPrefix, TUnit>>());
@@ -39,7 +39,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(this.quant.As<Metric<TUnit>>());
     }
     public Power ToMetric<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IPower
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>>());
@@ -55,7 +55,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(value.As<SiDerived<TUnit>>());
     }
     public static Power Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiDerivedUnit, IPower
     {
         return new(value.As<SiDerived<TPrefix, TUnit>>());
@@ -71,7 +71,7 @@ public readonly struct Power : IQuantity<Power>, IPower
         return new(value.As<Metric<TUnit>>());
     }
     public static Power Metric<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IPower
     {
         return new(value.As<Metric<TPrefix, TUnit>>());

--- a/quantities/quantities/Temperature.cs
+++ b/quantities/quantities/Temperature.cs
@@ -22,7 +22,7 @@ public readonly struct Temperature : IQuantity<Temperature>, ITemperature
         return new(this.quant.As<Si<TUnit>>());
     }
     public Temperature To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ITemperature
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -44,7 +44,7 @@ public readonly struct Temperature : IQuantity<Temperature>, ITemperature
         return new(value.As<Si<TUnit>>());
     }
     public static Temperature Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ITemperature
     {
         return new(value.As<Si<TPrefix, TUnit>>());

--- a/quantities/quantities/Temperature.cs
+++ b/quantities/quantities/Temperature.cs
@@ -22,7 +22,7 @@ public readonly struct Temperature : IQuantity<Temperature>, ITemperature
         return new(this.quant.As<Si<TUnit>>());
     }
     public Temperature To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ITemperature
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -44,7 +44,7 @@ public readonly struct Temperature : IQuantity<Temperature>, ITemperature
         return new(value.As<Si<TUnit>>());
     }
     public static Temperature Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ITemperature
     {
         return new(value.As<Si<TPrefix, TUnit>>());

--- a/quantities/quantities/Time.cs
+++ b/quantities/quantities/Time.cs
@@ -16,7 +16,7 @@ public readonly struct Time : IQuantity<Time>, ITime
     private Time(in Quant quant) => this.quant = quant;
     public Time ToSeconds() => new(this.quant.As<Si<Second>>());
     public Time To<TPrefix, TUnit>()
-        where TPrefix : IPrefix, IScaleDown
+        where TPrefix : ISiPrefix, IScaleDown
         where TUnit : ISiBaseUnit, ITime
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -29,7 +29,7 @@ public readonly struct Time : IQuantity<Time>, ITime
     public TimeSpan ToTimeSpan() => TimeSpan.FromSeconds(ToSeconds());
     public static Time Seconds(in Double value) => new(value.As<Si<Second>>());
     public static Time Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix, IScaleDown
+        where TPrefix : ISiPrefix, IScaleDown
         where TUnit : ISiBaseUnit, ITime
     {
         return new(value.As<Si<TPrefix, TUnit>>());

--- a/quantities/quantities/Time.cs
+++ b/quantities/quantities/Time.cs
@@ -8,6 +8,8 @@ namespace Quantities.Quantities;
 
 public readonly struct Time : IQuantity<Time>, ITime
     , IMultiplyOperators<Time, Power, Energy>
+    , IMultiplyOperators<Time, Velocity, Length>
+    , IMultiplyOperators<Time, DataRate, Data>
 // ToDo: Can't apply ISi, or IOther interfaces...
 {
     private static readonly Creator create = new();
@@ -62,6 +64,9 @@ public readonly struct Time : IQuantity<Time>, ITime
     public static Time operator /(Time left, Double scalar) => new(left.quant / scalar);
     public static Double operator /(Time left, Time right) => left.quant / right.quant;
     public static Energy operator *(Time left, Power right) => Energy.From(in right, in left);
+
+    public static Length operator *(Time left, Velocity right) => Length.From(in right, in left);
+    public static Data operator *(Time left, DataRate right) => Data.From(in left, in right);
 
     private sealed class Creator : IPrefixInject<Quant>
     {

--- a/quantities/quantities/Time.cs
+++ b/quantities/quantities/Time.cs
@@ -16,7 +16,7 @@ public readonly struct Time : IQuantity<Time>, ITime
     private Time(in Quant quant) => this.quant = quant;
     public Time ToSeconds() => new(this.quant.As<Si<Second>>());
     public Time To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix, IScaleDown
+        where TPrefix : IMetricPrefix, IScaleDown
         where TUnit : ISiBaseUnit, ITime
     {
         return new(this.quant.As<Si<TPrefix, TUnit>>());
@@ -29,7 +29,7 @@ public readonly struct Time : IQuantity<Time>, ITime
     public TimeSpan ToTimeSpan() => TimeSpan.FromSeconds(ToSeconds());
     public static Time Seconds(in Double value) => new(value.As<Si<Second>>());
     public static Time Si<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix, IScaleDown
+        where TPrefix : IMetricPrefix, IScaleDown
         where TUnit : ISiBaseUnit, ITime
     {
         return new(value.As<Si<TPrefix, TUnit>>());
@@ -43,7 +43,7 @@ public readonly struct Time : IQuantity<Time>, ITime
     internal static Time From(in Energy energy, in Power power)
     {
         // ToDo: Extract the time component!
-        return new(SiPrefix.ScaleThree(energy.Quant.SiDivide(power.Quant), create));
+        return new(MetricPrefix.ScaleThree(energy.Quant.SiDivide(power.Quant), create));
     }
 
     public Boolean Equals(Time other) => this.quant.Equals(other.quant);

--- a/quantities/quantities/Velocity.cs
+++ b/quantities/quantities/Velocity.cs
@@ -20,7 +20,7 @@ public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
         return new Transform<Velocity, Si<TUnit>>(in this.quant);
     }
     public IBuilder<Velocity> To<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new Transform<Velocity, Si<TPrefix, TUnit>>(in this.quant);
@@ -33,7 +33,7 @@ public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
     public static IBuilder<Velocity> Si<TUnit>(in Double value)
         where TUnit : ISiBaseUnit, ILength => new Builder<Velocity, Si<TUnit>>(in value);
     public static IBuilder<Velocity> Si<TPrefix, TUnit>(in Double value)
-    where TPrefix : IPrefix
+    where TPrefix : ISiPrefix
     where TUnit : ISiBaseUnit, ILength
     {
         return new Builder<Velocity, Si<TPrefix, TUnit>>(in value);

--- a/quantities/quantities/Velocity.cs
+++ b/quantities/quantities/Velocity.cs
@@ -10,6 +10,7 @@ namespace Quantities.Quantities;
 
 public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
     , IMultiplyOperators<Velocity, Force, Power>
+    , IMultiplyOperators<Velocity, Time, Length>
 {
     private static readonly Creator create = new();
     private readonly Quant quant;
@@ -67,6 +68,7 @@ public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
     public static Double operator /(Velocity left, Velocity right) => left.quant / right.quant;
 
     public static Power operator *(Velocity velocity, Force force) => Power.From(in force, in velocity);
+    public static Length operator *(Velocity left, Time right) => Length.From(in left, in right);
 
     private sealed class Creator : IPrefixInject<Quant>
     {

--- a/quantities/quantities/Velocity.cs
+++ b/quantities/quantities/Velocity.cs
@@ -20,7 +20,7 @@ public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
         return new Transform<Velocity, Si<TUnit>>(in this.quant);
     }
     public IBuilder<Velocity> To<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new Transform<Velocity, Si<TPrefix, TUnit>>(in this.quant);
@@ -33,7 +33,7 @@ public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
     public static IBuilder<Velocity> Si<TUnit>(in Double value)
         where TUnit : ISiBaseUnit, ILength => new Builder<Velocity, Si<TUnit>>(in value);
     public static IBuilder<Velocity> Si<TPrefix, TUnit>(in Double value)
-    where TPrefix : ISiPrefix
+    where TPrefix : IMetricPrefix
     where TUnit : ISiBaseUnit, ILength
     {
         return new Builder<Velocity, Si<TPrefix, TUnit>>(in value);
@@ -45,7 +45,7 @@ public readonly struct Velocity : IQuantity<Velocity>, IVelocity<Length, Time>
     }
     internal static Velocity From(in Power power, in Force force)
     {
-        return new(SiPrefix.Scale(power.Quant.SiDivide(force.Quant), create));
+        return new(MetricPrefix.Scale(power.Quant.SiDivide(force.Quant), create));
     }
     internal static Velocity From(in Length length, in Time time) => new(length.Quant.Divide(time.Quant));
 

--- a/quantities/quantities/Volume.cs
+++ b/quantities/quantities/Volume.cs
@@ -21,7 +21,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(this.quant.To<Cube, Si<TUnit>>());
     }
     public Volume ToCubic<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(this.quant.To<Cube, Si<TPrefix, TUnit>>());
@@ -32,7 +32,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(this.quant.As<Metric<TVolume>, Alias<TVolume, ILength>>());
     }
     public Volume ToMetric<TPrefix, TUnit>()
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : IMetricUnit, IVolume<ILength>, IInjectUnit<ILength>
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>, Alias<TPrefix, TUnit, ILength>>());
@@ -53,7 +53,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(value.To<Cube, Si<TUnit>>());
     }
     public static Volume Cubic<TPrefix, TUnit>(in Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(value.To<Cube, Si<TPrefix, TUnit>>());
@@ -64,7 +64,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(value.As<Metric<TVolume>, Alias<TVolume, ILength>>());
     }
     public static Volume Metric<TPrefix, TVolume>(Double value)
-        where TPrefix : IPrefix
+        where TPrefix : ISiPrefix
         where TVolume : IMetricUnit, IVolume<ILength>, IInjectUnit<ILength>
     {
         return new(value.As<Metric<TPrefix, TVolume>, Alias<TPrefix, TVolume, ILength>>());

--- a/quantities/quantities/Volume.cs
+++ b/quantities/quantities/Volume.cs
@@ -21,7 +21,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(this.quant.To<Cube, Si<TUnit>>());
     }
     public Volume ToCubic<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(this.quant.To<Cube, Si<TPrefix, TUnit>>());
@@ -32,7 +32,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(this.quant.As<Metric<TVolume>, Alias<TVolume, ILength>>());
     }
     public Volume ToMetric<TPrefix, TUnit>()
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : IMetricUnit, IVolume<ILength>, IInjectUnit<ILength>
     {
         return new(this.quant.As<Metric<TPrefix, TUnit>, Alias<TPrefix, TUnit, ILength>>());
@@ -53,7 +53,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(value.To<Cube, Si<TUnit>>());
     }
     public static Volume Cubic<TPrefix, TUnit>(in Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TUnit : ISiBaseUnit, ILength
     {
         return new(value.To<Cube, Si<TPrefix, TUnit>>());
@@ -64,7 +64,7 @@ public readonly struct Volume : IQuantity<Volume>, IVolume<Length>
         return new(value.As<Metric<TVolume>, Alias<TVolume, ILength>>());
     }
     public static Volume Metric<TPrefix, TVolume>(Double value)
-        where TPrefix : ISiPrefix
+        where TPrefix : IMetricPrefix
         where TVolume : IMetricUnit, IVolume<ILength>, IInjectUnit<ILength>
     {
         return new(value.As<Metric<TPrefix, TVolume>, Alias<TPrefix, TVolume, ILength>>());

--- a/quantities/quantities/builders/Builder.cs
+++ b/quantities/quantities/builders/Builder.cs
@@ -4,7 +4,7 @@ using Quantities.Measures;
 namespace Quantities.Quantities.Builders;
 
 internal sealed class Builder<TQuantity, TNominator> : IBuilder<TQuantity>
-    where TQuantity : Dimensions.IDimension, IEquatable<TQuantity>, IFormattable
+    where TQuantity : struct, IQuantity<TQuantity>, Dimensions.IDimension
     where TNominator : IMeasure, ILinear
 {
     private readonly Double value;

--- a/quantities/quantities/builders/IBuilder.cs
+++ b/quantities/quantities/builders/IBuilder.cs
@@ -3,7 +3,7 @@ using Quantities.Measures;
 namespace Quantities.Quantities.Builders;
 
 public interface IBuilder<out TQuantity>
-    where TQuantity : Dimensions.IDimension, IEquatable<TQuantity>, IFormattable
+    where TQuantity : struct, IQuantity<TQuantity>, Dimensions.IDimension
 {
     internal Quant By<TMeasure>() where TMeasure : IMeasure;
 }

--- a/quantities/quantities/builders/Transform.cs
+++ b/quantities/quantities/builders/Transform.cs
@@ -4,7 +4,7 @@ using Quantities.Measures;
 namespace Quantities.Quantities.Builders;
 
 internal sealed class Transform<TQuantity, TNominator> : IBuilder<TQuantity>
-    where TQuantity : Dimensions.IDimension, IEquatable<TQuantity>, IFormattable
+    where TQuantity : struct, IQuantity<TQuantity>, Dimensions.IDimension
     where TNominator : IMeasure, ILinear
 {
     private readonly Quant quant;

--- a/quantities/units/Other/Area/Morgen.cs
+++ b/quantities/units/Other/Area/Morgen.cs
@@ -1,9 +1,7 @@
 using Quantities.Dimensions;
-using Quantities.Units;
-using Quantities.Units.Other;
 using Quantities.Units.Si;
 
-namespace Quantities.Unitss.Other.Area;
+namespace Quantities.Units.Other.Area;
 
 // See: https://de.wikipedia.org/wiki/Morgen_(Einheit)
 public readonly struct Morgen : IOther, IArea<ILength>, IInjectUnit<ILength>

--- a/quantities/units/Si/IMetricUnit.cs
+++ b/quantities/units/Si/IMetricUnit.cs
@@ -8,7 +8,7 @@ namespace Quantities.Units.Si;
 /// </summary>
 public interface IMetricUnit : ITransform, IUnit { /* marker interface */ }
 public interface IMetricUnit<TPrefix> : IMetricUnit
-    where TPrefix : IPrefix
+    where TPrefix : ISiPrefix
 {
     static Double ITransform.ToSi(in Double value) => TPrefix.ToSi(in value);
     static Double ITransform.FromSi(in Double value) => TPrefix.FromSi(in value);

--- a/quantities/units/Si/IMetricUnit.cs
+++ b/quantities/units/Si/IMetricUnit.cs
@@ -12,7 +12,7 @@ public interface IMetricUnit : ITransform, IUnit
     static Double ITransform.FromSi(in Double value) => value;
 }
 public interface IMetricUnit<TPrefix> : IMetricUnit
-    where TPrefix : ISiPrefix
+    where TPrefix : IMetricPrefix
 {
     static Double ITransform.ToSi(in Double value) => TPrefix.ToSi(in value);
     static Double ITransform.FromSi(in Double value) => TPrefix.FromSi(in value);

--- a/quantities/units/Si/IMetricUnit.cs
+++ b/quantities/units/Si/IMetricUnit.cs
@@ -6,7 +6,11 @@ namespace Quantities.Units.Si;
 /// Metric units are accepted by the SI system, but are themselves not considered to be
 //  SI units.
 /// </summary>
-public interface IMetricUnit : ITransform, IUnit { /* marker interface */ }
+public interface IMetricUnit : ITransform, IUnit
+{
+    static Double ITransform.ToSi(in Double value) => value;
+    static Double ITransform.FromSi(in Double value) => value;
+}
 public interface IMetricUnit<TPrefix> : IMetricUnit
     where TPrefix : ISiPrefix
 {

--- a/quantities/units/Si/ISiBaseUnit.cs
+++ b/quantities/units/Si/ISiBaseUnit.cs
@@ -1,5 +1,3 @@
 ﻿namespace Quantities.Units.Si;
 
-public interface ISiBaseUnit : ISiUnit
-{
-}
+public interface ISiBaseUnit : ISiUnit { /* marker interface */ }

--- a/quantities/units/Si/ISiDerivedUnit.cs
+++ b/quantities/units/Si/ISiDerivedUnit.cs
@@ -10,7 +10,7 @@ public interface ISiDerivedUnit : ISiUnit, ITransform
 }
 
 public interface ISiDerivedUnit<TPrefix> : ISiDerivedUnit
-    where TPrefix : ISiPrefix
+    where TPrefix : IMetricPrefix
 {
     static Double ITransform.ToSi(in Double value) => TPrefix.ToSi(in value);
     static Double ITransform.FromSi(in Double value) => TPrefix.FromSi(in value);

--- a/quantities/units/Si/ISiDerivedUnit.cs
+++ b/quantities/units/Si/ISiDerivedUnit.cs
@@ -10,7 +10,7 @@ public interface ISiDerivedUnit : ISiUnit, ITransform
 }
 
 public interface ISiDerivedUnit<TPrefix> : ISiDerivedUnit
-    where TPrefix : IPrefix
+    where TPrefix : ISiPrefix
 {
     static Double ITransform.ToSi(in Double value) => TPrefix.ToSi(in value);
     static Double ITransform.FromSi(in Double value) => TPrefix.FromSi(in value);

--- a/quantities/units/Si/ISiUnit.cs
+++ b/quantities/units/Si/ISiUnit.cs
@@ -1,5 +1,3 @@
 ﻿namespace Quantities.Units.Si;
 
-public interface ISiUnit : IUnit
-{
-}
+public interface ISiUnit : IUnit { /* marker interface */ }

--- a/quantities/units/Si/Metric/UnitsOfInformation.cs
+++ b/quantities/units/Si/Metric/UnitsOfInformation.cs
@@ -1,0 +1,27 @@
+using Quantities.Dimensions;
+
+namespace Quantities.Units.Si.Metric;
+
+/* There is not SI unit for "amount of information".
+Wikipedia seems to suggest it's best to define the 'bit' as the base unit.
+This is what we'll use here...
+--> https://en.wikipedia.org/wiki/Byte "unit derived from bit"
+*/
+public readonly struct Bit : IMetricUnit, IAmountOfInformation
+{
+    public static String Representation => "bit";
+}
+public readonly struct Nibble : IMetricUnit, IAmountOfInformation
+{
+    private const Double toBit = 4d;
+    public static Double ToSi(in Double value) => value * toBit;
+    public static Double FromSi(in Double value) => value / toBit;
+    public static String Representation => "N"; // ToDo: What should be defined here??
+}
+public readonly struct Byte : IMetricUnit, IAmountOfInformation
+{
+    private const Double toBit = 8d;
+    public static Double ToSi(in Double value) => value * toBit;
+    public static Double FromSi(in Double value) => value / toBit;
+    public static String Representation => "B";
+}

--- a/quantities/units/Si/Metric/UnitsOfInformation.cs
+++ b/quantities/units/Si/Metric/UnitsOfInformation.cs
@@ -2,7 +2,7 @@ using Quantities.Dimensions;
 
 namespace Quantities.Units.Si.Metric;
 
-/* There is not SI unit for "amount of information".
+/* There is no SI unit for "amount of information".
 Wikipedia seems to suggest it's best to define the 'bit' as the base unit.
 This is what we'll use here...
 --> https://en.wikipedia.org/wiki/Byte "unit derived from bit"
@@ -16,7 +16,7 @@ public readonly struct Nibble : IMetricUnit, IAmountOfInformation
     private const Double toBit = 4d;
     public static Double ToSi(in Double value) => value * toBit;
     public static Double FromSi(in Double value) => value / toBit;
-    public static String Representation => "N"; // ToDo: What should be defined here??
+    public static String Representation => "N";
 }
 public readonly struct Byte : IMetricUnit, IAmountOfInformation
 {


### PR DESCRIPTION
Add binary prefixes.

- Rename SiPrefix -> MetricPrefix
- Add second family of prefixes, the binary prefixes
- Improve assertion of pounded precision
- Add units for amount of data and data rate
- Add Data and DataRate quantities