### PR TITLE
Fix namespace on NauticalMile.

### DIFF
--- a/source/Quantities.Test/VelocityTest.cs
+++ b/source/Quantities.Test/VelocityTest.cs
@@ -1,4 +1,4 @@
-﻿using Quantities.units.NonStandard.Length;
+﻿using Quantities.Units.NonStandard.Length;
 using Quantities.Units.NonStandard.Velocity;
 using Quantities.Units.Si.Metric;
 

--- a/source/Quantities.Units/NonStandard/Length/NauticalMile.cs
+++ b/source/Quantities.Units/NonStandard/Length/NauticalMile.cs
@@ -1,8 +1,7 @@
 ﻿using Quantities.Dimensions;
-using Quantities.Units;
 using Quantities.Units.Si;
 
-namespace Quantities.units.NonStandard.Length;
+namespace Quantities.Units.NonStandard.Length;
 
 // https://en.wikipedia.org/wiki/Nautical_mile
 public readonly struct NauticalMile : INonStandardUnit, ILength

--- a/source/Quantities.Units/NonStandard/Velocity/Knot.cs
+++ b/source/Quantities.Units/NonStandard/Velocity/Knot.cs
@@ -1,5 +1,5 @@
 ﻿using Quantities.Dimensions;
-using Quantities.units.NonStandard.Length;
+using Quantities.Units.NonStandard.Length;
 using Quantities.Units.Si.Metric;
 using static Quantities.Extensions;
 


### PR DESCRIPTION
Change the namespace of `NauticalMile` from `Quantities.units.[...]` to `Quantities.Units.[...]`.